### PR TITLE
fix: Correct build and deployment for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,6 @@
     <div id="root"></div>
     
     <!-- Custom JavaScript -->
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "start": "python -m http.server 8000",
     "serve": "npx serve .",
-    "build": "npx esbuild spelling-bee-game.tsx --bundle --outfile=app.js --jsx=automatic --external:react --external:lucide-react",
+    "build": "rm -rf dist && mkdir dist && cp index.html style.css dist/ && npx esbuild spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --external:react --external:lucide-react",
     "watch": "npx esbuild spelling-bee-game.tsx --bundle --outfile=app.js --jsx=automatic --external:react --external:lucide-react --watch",
     "test": "echo 'No tests configured yet'",
-    "deploy": "gh-pages -d ."
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The existing build and deployment process was not correctly configured for GitHub Pages. The `deploy` script was pushing the source files instead of the built application.

This commit introduces the following changes:
- The `build` script in `package.json` now outputs the bundled application to a `dist` directory.
- `index.html` and `style.css` are copied to the `dist` directory during the build process.
- A `predeploy` script is added to automatically build the project before deployment.
- The `deploy` script now deploys the contents of the `dist` directory using `gh-pages`.
- The script tag in `index.html` is updated to include `type="module"` to ensure the browser correctly loads the ES module output by `esbuild`.

These changes ensure that the application is correctly built and deployed to GitHub Pages.