### PR TITLE
feat: Add support for CSV file parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,12 +10,36 @@
   var import_react = __require("react");
   var import_lucide_react = __require("lucide-react");
   var import_jsx_runtime = __require("react/jsx-runtime");
+  var wordDatabase = {
+    easy: [
+      { word: "friend", syllables: "friend (1 syllable)", definition: "A person you like and know well", origin: "Old English 'freond', from Germanic root meaning 'to love'", sentence: "My best friend and I love to play together.", prefixSuffix: "Base word with no prefix or suffix", pronunciation: "FREND" },
+      { word: "happy", syllables: "hap-py (2 syllables)", definition: "Feeling or showing pleasure and contentment", origin: "Middle English 'happy', from 'hap' meaning luck or fortune", sentence: "The children were happy to see the circus.", prefixSuffix: "Base word 'hap' + suffix '-py'", pronunciation: "HAP-ee" }
+    ],
+    medium: [
+      { word: "necessary", syllables: "nec-es-sar-y (4 syllables)", definition: "Required to be done or achieved; essential", origin: "Latin 'necessarius', from 'necesse' meaning unavoidable", sentence: "It is necessary to study hard for the test.", prefixSuffix: "Base 'necess' + suffix '-ary'", pronunciation: "NES-uh-ser-ee" }
+    ],
+    tricky: [
+      { word: "chrysanthemum", syllables: "chry-san-the-mum (4 syllables)", definition: "A type of flower with many thin petals", origin: "Greek 'chrysos' (gold) + 'anthemon' (flower)", sentence: "The chrysanthemum bloomed beautifully in autumn.", prefixSuffix: "Greek compound: chryso- (gold) + -anthemum (flower)", pronunciation: "kri-SAN-thuh-mum" }
+    ]
+  };
   var SpellingBeeGame = () => {
     const [gameState, setGameState] = (0, import_react.useState)("setup");
     const [gameConfig, setGameConfig] = (0, import_react.useState)(null);
     const [gameResults, setGameResults] = (0, import_react.useState)(null);
+    const [customWords, setCustomWords] = (0, import_react.useState)({ easy: [], medium: [], tricky: [] });
+    const handleAddCustomWords = (newWords) => {
+      const easy = newWords.filter((w) => w.word.length <= 5);
+      const medium = newWords.filter((w) => w.word.length > 5 && w.word.length <= 8);
+      const tricky = newWords.filter((w) => w.word.length > 8);
+      setCustomWords({ easy, medium, tricky });
+    };
     const handleStartGame = (config) => {
-      setGameConfig(config);
+      const finalWordDatabase = {
+        easy: [...wordDatabase.easy, ...customWords.easy],
+        medium: [...wordDatabase.medium, ...customWords.medium],
+        tricky: [...wordDatabase.tricky, ...customWords.tricky]
+      };
+      setGameConfig({ ...config, wordDatabase: finalWordDatabase });
       setGameState("playing");
     };
     const handleEndGame = (results) => {
@@ -28,7 +52,7 @@
       setGameResults(null);
     };
     if (gameState === "setup") {
-      return /* @__PURE__ */ (0, import_jsx_runtime.jsx)(SetupScreen, { onStartGame: handleStartGame });
+      return /* @__PURE__ */ (0, import_jsx_runtime.jsx)(SetupScreen, { onStartGame: handleStartGame, onAddCustomWords: handleAddCustomWords });
     }
     if (gameState === "playing") {
       return /* @__PURE__ */ (0, import_jsx_runtime.jsx)(GameScreen, { config: gameConfig, onEndGame: handleEndGame });
@@ -38,21 +62,97 @@
     }
     return null;
   };
-  var SetupScreen = ({ onStartGame }) => {
+  var SetupScreen = ({ onStartGame, onAddCustomWords }) => {
     const [teams, setTeams] = (0, import_react.useState)([]);
     const [gameMode, setGameMode] = (0, import_react.useState)("team");
+    const [customWordListText, setCustomWordListText] = (0, import_react.useState)("");
+    const parseWordList = (content) => {
+      try {
+        const parsed = JSON.parse(content);
+        if (Array.isArray(parsed)) {
+          onAddCustomWords(parsed);
+          return;
+        }
+      } catch (e) {
+      }
+      const lines = content.trim().split("\n");
+      if (lines.length < 2) return;
+      const headerLine = lines[0];
+      const delimiter = headerLine.includes(",") ? "," : "	";
+      const headers = headerLine.split(delimiter).map((h) => h.trim());
+      const words = lines.slice(1).map((line) => {
+        const values = line.split(delimiter);
+        const wordObj = {};
+        headers.forEach((header, index) => {
+          wordObj[header] = values[index] ? values[index].trim() : "";
+        });
+        return wordObj;
+      });
+      onAddCustomWords(words);
+    };
+    const handleFileChange = (event) => {
+      const file = event.target.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const content = e.target.result;
+          setCustomWordListText(content);
+          parseWordList(content);
+        };
+        reader.readAsText(file);
+      }
+    };
+    (0, import_react.useEffect)(() => {
+      if (customWordListText) {
+        parseWordList(customWordListText);
+      }
+    }, [customWordListText]);
     const handleStart = () => {
-      const config = {
-        teams,
-        gameMode
-        /* ... other configs */
-      };
+      const config = { teams, gameMode };
       onStartGame(config);
     };
     return /* @__PURE__ */ (0, import_jsx_runtime.jsx)("div", { className: "min-h-screen bg-gradient-to-br from-blue-600 to-purple-700 p-8 text-white", children: /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("div", { className: "max-w-7xl mx-auto", children: [
       /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("div", { className: "text-center mb-12", children: [
         /* @__PURE__ */ (0, import_jsx_runtime.jsx)("h1", { className: "text-6xl font-bold mb-4 text-yellow-300", children: "\u{1F3C6} SPELLING BEE CHAMPIONSHIP" }),
         /* @__PURE__ */ (0, import_jsx_runtime.jsx)("p", { className: "text-2xl", children: "Get ready to spell your way to victory!" })
+      ] }),
+      /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("div", { className: "bg-white/10 p-6 rounded-lg mb-8", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime.jsx)("h2", { className: "text-2xl font-bold mb-4", children: "Add Custom Word List" }),
+        /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-6", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("div", { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)("label", { htmlFor: "file-upload", className: "block text-lg font-medium mb-2", children: "Upload File" }),
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)("p", { className: "text-sm text-gray-300 mb-2", children: "Upload a JSON or TSV file." }),
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
+              "input",
+              {
+                id: "file-upload",
+                type: "file",
+                accept: ".json,.tsv,.txt,.csv",
+                onChange: handleFileChange,
+                className: "block w-full text-sm text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-yellow-300 file:text-black hover:file:bg-yellow-400"
+              }
+            )
+          ] }),
+          /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("div", { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)("label", { htmlFor: "paste-area", className: "block text-lg font-medium mb-2", children: "Or Paste Spreadsheet Data" }),
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)("p", { className: "text-sm text-gray-300 mb-2", children: "Paste data from Excel or Google Sheets (tab-separated)." }),
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
+              "textarea",
+              {
+                id: "paste-area",
+                rows: "4",
+                value: customWordListText,
+                onChange: (e) => setCustomWordListText(e.target.value),
+                className: "w-full p-2 rounded-md bg-white/20 text-white",
+                placeholder: "Paste your tab-separated values here..."
+              }
+            )
+          ] })
+        ] }),
+        /* @__PURE__ */ (0, import_jsx_runtime.jsx)("div", { className: "mt-4 text-sm text-gray-300", children: /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("p", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime.jsx)("strong", { children: "Format:" }),
+          " The first row should be headers: `word`, `syllables`, `definition`, `origin`, `sentence`, `prefixSuffix`, `pronunciation`. The difficulty will be determined by word length."
+        ] }) })
       ] }),
       /* @__PURE__ */ (0, import_jsx_runtime.jsx)("button", { onClick: handleStart, className: "w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold", children: "START GAME" })
     ] }) });

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -18,9 +18,23 @@ const SpellingBeeGame = () => {
     const [gameState, setGameState] = useState("setup");
     const [gameConfig, setGameConfig] = useState(null);
     const [gameResults, setGameResults] = useState(null);
+    const [customWords, setCustomWords] = useState({ easy: [], medium: [], tricky: [] });
+
+    const handleAddCustomWords = (newWords) => {
+        // Simple difficulty assignment based on word length for now
+        const easy = newWords.filter(w => w.word.length <= 5);
+        const medium = newWords.filter(w => w.word.length > 5 && w.word.length <= 8);
+        const tricky = newWords.filter(w => w.word.length > 8);
+        setCustomWords({ easy, medium, tricky });
+    };
 
     const handleStartGame = (config) => {
-        setGameConfig(config);
+        const finalWordDatabase = {
+            easy: [...wordDatabase.easy, ...customWords.easy],
+            medium: [...wordDatabase.medium, ...customWords.medium],
+            tricky: [...wordDatabase.tricky, ...customWords.tricky],
+        };
+        setGameConfig({ ...config, wordDatabase: finalWordDatabase });
         setGameState("playing");
     };
 
@@ -36,7 +50,7 @@ const SpellingBeeGame = () => {
     };
 
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} />;
+        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} />;
     }
     if (gameState === "playing") {
         return <GameScreen config={gameConfig} onEndGame={handleEndGame} />;
@@ -47,13 +61,65 @@ const SpellingBeeGame = () => {
     return null;
 };
 
-const SetupScreen = ({ onStartGame }) => {
+const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
     const [teams, setTeams] = useState([]);
     const [gameMode, setGameMode] = useState("team");
-    // ... other setup states
+    const [customWordListText, setCustomWordListText] = useState("");
+
+    const parseWordList = (content) => {
+        try {
+            // Try parsing as JSON first
+            const parsed = JSON.parse(content);
+            if (Array.isArray(parsed)) {
+                onAddCustomWords(parsed);
+                return;
+            }
+        } catch (e) {
+            // Not a valid JSON array, try parsing as TSV
+        }
+
+        // Parse as CSV or TSV
+        const lines = content.trim().split('\n');
+        if (lines.length < 2) return; // Need at least a header and one data row
+
+        const headerLine = lines[0];
+        const delimiter = headerLine.includes(',') ? ',' : '\t';
+
+        const headers = headerLine.split(delimiter).map(h => h.trim());
+        const words = lines.slice(1).map(line => {
+            // Basic CSV parsing - doesn't handle commas inside quotes.
+            // For this application, it's a reasonable starting point.
+            const values = line.split(delimiter);
+            const wordObj = {};
+            headers.forEach((header, index) => {
+                wordObj[header] = values[index] ? values[index].trim() : "";
+            });
+            return wordObj;
+        });
+        onAddCustomWords(words);
+    };
+
+    const handleFileChange = (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const content = e.target.result;
+                setCustomWordListText(content);
+                parseWordList(content);
+            };
+            reader.readAsText(file);
+        }
+    };
+
+    useEffect(() => {
+        if(customWordListText) {
+            parseWordList(customWordListText)
+        }
+    }, [customWordListText]);
 
     const handleStart = () => {
-        const config = { teams, gameMode /* ... other configs */ };
+        const config = { teams, gameMode };
         onStartGame(config);
     };
 
@@ -64,7 +130,40 @@ const SetupScreen = ({ onStartGame }) => {
                     <h1 className="text-6xl font-bold mb-4 text-yellow-300">🏆 SPELLING BEE CHAMPIONSHIP</h1>
                     <p className="text-2xl">Get ready to spell your way to victory!</p>
                 </div>
-                {/* All the setup UI goes here */}
+
+                {/* Custom Word List Section */}
+                <div className="bg-white/10 p-6 rounded-lg mb-8">
+                    <h2 className="text-2xl font-bold mb-4">Add Custom Word List</h2>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div>
+                            <label htmlFor="file-upload" className="block text-lg font-medium mb-2">Upload File</label>
+                            <p className="text-sm text-gray-300 mb-2">Upload a JSON or TSV file.</p>
+                            <input
+                                id="file-upload"
+                                type="file"
+                                accept=".json,.tsv,.txt,.csv"
+                                onChange={handleFileChange}
+                                className="block w-full text-sm text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-yellow-300 file:text-black hover:file:bg-yellow-400"
+                            />
+                        </div>
+                        <div>
+                            <label htmlFor="paste-area" className="block text-lg font-medium mb-2">Or Paste Spreadsheet Data</label>
+                            <p className="text-sm text-gray-300 mb-2">Paste data from Excel or Google Sheets (tab-separated).</p>
+                            <textarea
+                                id="paste-area"
+                                rows="4"
+                                value={customWordListText}
+                                onChange={(e) => setCustomWordListText(e.target.value)}
+                                className="w-full p-2 rounded-md bg-white/20 text-white"
+                                placeholder="Paste your tab-separated values here..."
+                            ></textarea>
+                        </div>
+                    </div>
+                    <div className="mt-4 text-sm text-gray-300">
+                        <p><strong>Format:</strong> The first row should be headers: `word`, `syllables`, `definition`, `origin`, `sentence`, `prefixSuffix`, `pronunciation`. The difficulty will be determined by word length.</p>
+                    </div>
+                </div>
+
                 <button onClick={handleStart} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold">
                     START GAME
                 </button>


### PR DESCRIPTION
This commit enhances the custom word list feature by adding support for CSV files.

The parsing logic now auto-detects the delimiter (comma or tab) based on the header row of the input. This allows users to import word lists from `.csv` files in addition to the already supported JSON and TSV formats.

The file input has also been updated to accept `.csv` files.