### PR TITLE
Use config word database for game word selection

### DIFF
--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -210,8 +210,8 @@ const GameScreen = ({ config, onEndGame }) => {
         return () => clearInterval(timer);
     }, [currentWord, timeLeft]);
 
-    const selectRandomWord = (difficulty) => {
-        const words = wordDatabase[difficulty] || wordDatabase.easy;
+    const selectRandomWord = (difficulty = 'easy') => {
+        const words = config.wordDatabase[difficulty] || config.wordDatabase.easy;
         const word = words[Math.floor(Math.random() * words.length)];
         setTimeLeft(config.timerDuration); // Reset timer when a new word is selected
         return word;
@@ -220,7 +220,7 @@ const GameScreen = ({ config, onEndGame }) => {
     const skipWord = () => {
         // Logic for skipping a word
         // For example, select a new word and move to the next turn
-        const newWord = selectRandomWord('easy'); // or current difficulty
+        const newWord = selectRandomWord(); // or current difficulty
         setCurrentWord(newWord);
         // maybe penalize the team
         nextTurn();
@@ -231,7 +231,7 @@ const GameScreen = ({ config, onEndGame }) => {
     };
 
     useEffect(() => {
-        setCurrentWord(selectRandomWord('easy'));
+        setCurrentWord(selectRandomWord());
     }, []);
 
     // Check for game over condition
@@ -269,7 +269,7 @@ const GameScreen = ({ config, onEndGame }) => {
         setTimeout(() => {
             setFeedback({ message: "", type: "" });
             setInputValue("");
-            const newWord = selectRandomWord('easy'); // or current difficulty
+            const newWord = selectRandomWord(); // or current difficulty
             setCurrentWord(newWord);
             nextTurn();
         }, 2000);


### PR DESCRIPTION
## Summary
- Use `config.wordDatabase` when picking a new word during gameplay.
- Default `selectRandomWord` to 'easy' difficulty and update callers (`skipWord`, initial selection).

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af40176d6c833283886e8dd143c896