### PR TITLE
Add bundled word lists and selection UI

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,6 +15,24 @@ fs.mkdirSync(distDir, { recursive: true });
 fs.copyFileSync('index.html', path.join(distDir, 'index.html'));
 fs.copyFileSync('style.css', path.join(distDir, 'style.css'));
 
+// Copy wordlists directory
+const copyDir = (src, dest) => {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+        const srcPath = path.join(src, entry.name);
+        const destPath = path.join(dest, entry.name);
+        if (entry.isDirectory()) {
+            copyDir(srcPath, destPath);
+        } else {
+            fs.copyFileSync(srcPath, destPath);
+        }
+    }
+};
+
+if (fs.existsSync('wordlists')) {
+    copyDir('wordlists', path.join(distDir, 'wordlists'));
+}
+
 // 3. Run esbuild to bundle the application
 esbuild.build({
     entryPoints: ['spelling-bee-game.tsx'],

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -70,6 +70,12 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
     const [gameMode, setGameMode] = useState("team");
     const [timerDuration, setTimerDuration] = useState(30);
     const [customWordListText, setCustomWordListText] = useState("");
+    const bundledWordLists = [
+        { label: "Example JSON", file: "example.json" },
+        { label: "Example CSV", file: "example.csv" },
+        { label: "Example TSV", file: "example.tsv" }
+    ];
+    const [selectedBundledList, setSelectedBundledList] = useState("");
 
     const parseWordList = (content) => {
         try {
@@ -111,11 +117,18 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
             reader.onload = (e) => {
                 const content = e.target.result;
                 setCustomWordListText(content);
-                parseWordList(content);
             };
             reader.readAsText(file);
         }
     };
+
+    useEffect(() => {
+        if (selectedBundledList) {
+            fetch(`wordlists/${selectedBundledList}`)
+                .then(res => res.text())
+                .then(text => setCustomWordListText(text));
+        }
+    }, [selectedBundledList]);
 
     useEffect(() => {
         if(customWordListText) {
@@ -139,6 +152,20 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
                 {/* Custom Word List Section */}
                 <div className="bg-white/10 p-6 rounded-lg mb-8">
                     <h2 className="text-2xl font-bold mb-4">Add Custom Word List</h2>
+                    <div className="mb-6">
+                        <label htmlFor="bundled-list" className="block text-lg font-medium mb-2">Choose Bundled Word List</label>
+                        <select
+                            id="bundled-list"
+                            value={selectedBundledList}
+                            onChange={(e) => setSelectedBundledList(e.target.value)}
+                            className="w-full p-2 rounded-md bg-white/20 text-white"
+                        >
+                            <option value="">-- Select a list --</option>
+                            {bundledWordLists.map(list => (
+                                <option key={list.file} value={list.file}>{list.label}</option>
+                            ))}
+                        </select>
+                    </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
                             <label htmlFor="file-upload" className="block text-lg font-medium mb-2">Upload File</label>

--- a/wordlists/example.csv
+++ b/wordlists/example.csv
@@ -1,0 +1,3 @@
+word,syllables,definition,origin,sentence,prefixSuffix,pronunciation
+apple,ap-ple,a fruit,Old English,She ate an apple.,,AP-uhl
+banana,ba-na-na,another fruit,Wolof,Bananas are yellow.,,buh-NA-nuh

--- a/wordlists/example.json
+++ b/wordlists/example.json
@@ -1,0 +1,20 @@
+[
+  {
+    "word": "apple",
+    "syllables": "ap-ple",
+    "definition": "a fruit",
+    "origin": "Old English",
+    "sentence": "She ate an apple.",
+    "prefixSuffix": "",
+    "pronunciation": "AP-uhl"
+  },
+  {
+    "word": "banana",
+    "syllables": "ba-na-na",
+    "definition": "another fruit",
+    "origin": "Wolof",
+    "sentence": "Bananas are yellow.",
+    "prefixSuffix": "",
+    "pronunciation": "buh-NA-nuh"
+  }
+]

--- a/wordlists/example.tsv
+++ b/wordlists/example.tsv
@@ -1,0 +1,3 @@
+word	syllables	definition	origin	sentence	prefixSuffix	pronunciation
+apple	ap-ple	a fruit	Old English	She ate an apple.		AP-uhl
+banana	ba-na-na	another fruit	Wolof	Bananas are yellow.		buh-NA-nuh


### PR DESCRIPTION
## Summary
- add `wordlists/` directory with example JSON/CSV/TSV lists
- allow selecting bundled word lists in setup screen
- copy bundled word lists in build step

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af4030511483329c7f579d580061b3