### PR TITLE
chore: ignore built app bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 build
 .DS_Store
+
+app.js


### PR DESCRIPTION
## Summary
- stop tracking generated app.js bundle and add it to .gitignore

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af4801dfbc833292af618afcbe6b60