### PR TITLE
Initialize points by player count

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Transform your spelling lessons into engaging, interactive competitions that stu
 - **Help Shop System** - Strategic point-based assistance options
 - **Incorrect Word Tracking** - Identify challenging words for future lessons
 - **Sound Effects** - Audio feedback for correct/incorrect answers
+- **Dynamic Scoring** - Starting points scale with player count with difficulty multipliers and streak bonuses
 
 ---
 

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -176,20 +176,36 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
     const handleStart = () => {
         let finalParticipants;
         if (gameMode === 'team') {
-            const trimmedTeams = teams.map(team => ({ ...team, name: team.name.trim() })).filter(team => team.name !== "");
+            const trimmedTeams = teams
+                .map(team => ({ ...team, name: team.name.trim() }))
+                .filter(team => team.name !== "");
             if (trimmedTeams.length < 2) {
                 setError("Please enter names for at least two teams.");
                 return;
             }
+            const startingPoints = trimmedTeams.length;
             // Combine point and streak fields with new stat-tracking fields
-            finalParticipants = trimmedTeams.map(t => ({ ...t, attempted: 0, correct: 0 }));
+            finalParticipants = trimmedTeams.map(t => ({
+                ...t,
+                points: startingPoints,
+                attempted: 0,
+                correct: 0,
+            }));
         } else {
-            const trimmedStudents = students.map(student => ({ ...student, name: student.name.trim() })).filter(student => student.name !== "");
+            const trimmedStudents = students
+                .map(student => ({ ...student, name: student.name.trim() }))
+                .filter(student => student.name !== "");
             if (trimmedStudents.length < 2) {
                 setError("Please enter names for at least two students.");
                 return;
             }
-            finalParticipants = trimmedStudents.map(s => ({ ...s, attempted: 0, correct: 0 }));
+            const startingPoints = trimmedStudents.length;
+            finalParticipants = trimmedStudents.map(s => ({
+                ...s,
+                points: startingPoints,
+                attempted: 0,
+                correct: 0,
+            }));
         }
         
         setError("");


### PR DESCRIPTION
## Summary
- Start each participant with points equal to the number of players
- Document dynamic scoring with difficulty multipliers and streak bonuses

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afcda5eb74833288c3660e1de4ec21