### PR TITLE
Add configurable skip penalty

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -231,6 +231,17 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     if (currentWord) {
       setWordQueues(prev => ({ ...prev, review: [...prev.review, currentWord] }));
     }
+    setParticipants(prev =>
+      prev.map((p, index) => {
+        if (index === currentParticipantIndex) {
+          if (config.skipPenaltyType === 'lives') {
+            return { ...p, lives: p.lives - config.skipPenaltyValue, streak: 0 };
+          }
+          return { ...p, points: p.points - config.skipPenaltyValue, streak: 0 };
+        }
+        return p;
+      })
+    );
     setAttemptedParticipants(new Set());
 
     setTimeout(() => {

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -28,6 +28,8 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
 
   const [students, setStudents] = useState<Participant[]>([]);
   const [studentName, setStudentName] = useState('');
+  const [skipPenaltyType, setSkipPenaltyType] = useState<'lives' | 'points'>('lives');
+  const [skipPenaltyValue, setSkipPenaltyValue] = useState(1);
 
   const addTeam = () => {
     setTeams([...teams, { name: '', lives: 5, points: 0, streak: 0, attempted: 0, correct: 0 }]);
@@ -157,7 +159,13 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     }
     onAddCustomWords(finalWords);
 
-    const config: GameConfig = { participants: finalParticipants, gameMode, timerDuration } as GameConfig;
+    const config: GameConfig = {
+      participants: finalParticipants,
+      gameMode,
+      timerDuration,
+      skipPenaltyType,
+      skipPenaltyValue
+    } as GameConfig;
     onStartGame(config);
   };
 
@@ -249,6 +257,27 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
               ))}
             </>
           )}
+        </div>
+
+        <div className="bg-white/10 p-6 rounded-lg mb-8">
+          <h2 className="text-2xl font-bold mb-4">Skip Penalty</h2>
+          <div className="flex gap-4">
+            <select
+              value={skipPenaltyType}
+              onChange={e => setSkipPenaltyType(e.target.value as 'lives' | 'points')}
+              className="p-2 rounded-md bg-white/20 text-white"
+            >
+              <option value="lives">Lives</option>
+              <option value="points">Points</option>
+            </select>
+            <input
+              type="number"
+              min={0}
+              value={skipPenaltyValue}
+              onChange={e => setSkipPenaltyValue(Number(e.target.value))}
+              className="p-2 rounded-md bg-white/20 text-white w-24"
+            />
+          </div>
         </div>
 
         <div className="bg-white/10 p-6 rounded-lg mb-8">

--- a/types.ts
+++ b/types.ts
@@ -29,6 +29,8 @@ export interface GameConfig {
   gameMode: 'team' | 'individual';
   timerDuration: number;
   wordDatabase: WordDatabase;
+  skipPenaltyType: 'lives' | 'points';
+  skipPenaltyValue: number;
 }
 
 export interface GameResults {


### PR DESCRIPTION
## Summary
- extend `GameConfig` with `skipPenaltyType` and `skipPenaltyValue`
- allow configuring skip penalty type and value in setup screen
- apply skip penalty to lives or points when skipping a word

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afdd4bed10833289e0a54797423e38