### PR TITLE
Track and display missed words after the game

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -256,7 +256,8 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       winner: activeParticipants.length === 1 ? activeParticipants[0] : null,
       participants: finalParticipants,
       gameMode: config.gameMode,
-      duration: Math.round((Date.now() - startTime) / 1000)
+      duration: Math.round((Date.now() - startTime) / 1000),
+      missedWords
     });
   };
 

--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -50,6 +50,17 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, onRestart }) => 
         ))}
       </div>
 
+      {results.missedWords && results.missedWords.length > 0 && (
+        <div className="bg-white/10 p-8 rounded-lg w-full max-w-md mt-8">
+          <h3 className="text-3xl font-bold mb-4">Missed Words</h3>
+          {results.missedWords.map((w, index) => (
+            <div key={index} className="text-left text-xl mb-2">
+              <span className="font-bold">{w.word}</span> - {w.definition}
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="flex gap-6 mt-12">
         <button
           onClick={handleExport}

--- a/types.ts
+++ b/types.ts
@@ -36,4 +36,5 @@ export interface GameResults {
   participants: Participant[];
   gameMode: 'team' | 'individual';
   duration: number;
+  missedWords: Word[];
 }


### PR DESCRIPTION
## Summary
- extend `GameResults` with `missedWords`
- pass missed words when ending the game
- show missed words list on results screen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afdd4b1ed883328f6ec150b781b06f