### PR TITLE
Track attempted and correct word counts for participants

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -24,7 +24,13 @@ interface WordQueues {
 
 const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const [participants, setParticipants] = useState<Participant[]>(
-    config.participants.map(p => ({ ...p, attempted: 0, correct: 0 }))
+    config.participants.map(p => ({
+      ...p,
+      attempted: 0,
+      correct: 0,
+      wordsAttempted: 0,
+      wordsCorrect: 0
+    }))
   );
   const [currentParticipantIndex, setCurrentParticipantIndex] = useState(0);
   const [currentWord, setCurrentWord] = useState<Word | null>(null);
@@ -242,6 +248,8 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
             ...p,
             attempted: p.attempted + 1,
             correct: p.correct + (isCorrect ? 1 : 0),
+            wordsAttempted: p.wordsAttempted + 1,
+            wordsCorrect: p.wordsCorrect + (isCorrect ? 1 : 0),
             lives: isCorrect ? p.lives : p.lives - 1,
             points: isCorrect ? p.points + pointsEarned : p.points,
             streak: isCorrect ? p.streak + 1 : 0
@@ -294,9 +302,19 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       prev.map((p, index) => {
         if (index === currentParticipantIndex) {
           if (config.skipPenaltyType === 'lives') {
-            return { ...p, lives: p.lives - config.skipPenaltyValue, streak: 0 };
+            return {
+              ...p,
+              lives: p.lives - config.skipPenaltyValue,
+              streak: 0,
+              wordsAttempted: p.wordsAttempted + 1
+            };
           }
-          return { ...p, points: p.points - config.skipPenaltyValue, streak: 0 };
+          return {
+            ...p,
+            points: p.points - config.skipPenaltyValue,
+            streak: 0,
+            wordsAttempted: p.wordsAttempted + 1
+          };
         }
         return p;
       })
@@ -320,7 +338,8 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     const activeParticipants = participants.filter(p => p.lives > 0);
     const finalParticipants = participants.map(p => ({
       ...p,
-      accuracy: p.attempted > 0 ? (p.correct / p.attempted) * 100 : 0
+      accuracy:
+        p.wordsAttempted > 0 ? (p.wordsCorrect / p.wordsAttempted) * 100 : 0
     }));
     onEndGame({
       winner: activeParticipants.length === 1 ? activeParticipants[0] : null,

--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -44,7 +44,11 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, onRestart }) => 
           <div key={index} className="text-left text-xl mb-3">
             <div className="font-bold">{p.name}</div>
             <div className="text-yellow-300">
-              {p.correct}/{p.attempted} correct ({(p.correct / p.attempted * 100).toFixed(0)}%) - {p.lives} lives remaining - {p.points} points
+              {p.wordsCorrect}/{p.wordsAttempted} correct (
+              {p.wordsAttempted > 0
+                ? Math.round((p.wordsCorrect / p.wordsAttempted) * 100)
+                : 0}
+              %) - {p.lives} lives remaining - {p.points} points
             </div>
           </div>
         ))}

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -8,8 +8,26 @@ interface SetupScreenProps {
 
 const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords }) => {
   const [teams, setTeams] = useState<Participant[]>([
-    { name: 'Team Alpha', lives: 5, points: 0, streak: 0, attempted: 0, correct: 0 },
-    { name: 'Team Beta', lives: 5, points: 0, streak: 0, attempted: 0, correct: 0 }
+    {
+      name: 'Team Alpha',
+      lives: 5,
+      points: 0,
+      streak: 0,
+      attempted: 0,
+      correct: 0,
+      wordsAttempted: 0,
+      wordsCorrect: 0
+    },
+    {
+      name: 'Team Beta',
+      lives: 5,
+      points: 0,
+      streak: 0,
+      attempted: 0,
+      correct: 0,
+      wordsAttempted: 0,
+      wordsCorrect: 0
+    }
   ]);
   const [gameMode, setGameMode] = useState<'team' | 'individual'>('team');
   const [timerDuration] = useState(30);
@@ -32,7 +50,19 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [skipPenaltyValue, setSkipPenaltyValue] = useState(1);
 
   const addTeam = () => {
-    setTeams([...teams, { name: '', lives: 5, points: 0, streak: 0, attempted: 0, correct: 0 }]);
+    setTeams([
+      ...teams,
+      {
+        name: '',
+        lives: 5,
+        points: 0,
+        streak: 0,
+        attempted: 0,
+        correct: 0,
+        wordsAttempted: 0,
+        wordsCorrect: 0
+      }
+    ]);
   };
 
   const removeTeam = (index: number) => {
@@ -48,7 +78,16 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     if (studentName.trim()) {
       setStudents([
         ...students,
-        { name: studentName.trim(), lives: 5, points: 0, streak: 0, attempted: 0, correct: 0 }
+        {
+          name: studentName.trim(),
+          lives: 5,
+          points: 0,
+          streak: 0,
+          attempted: 0,
+          correct: 0,
+          wordsAttempted: 0,
+          wordsCorrect: 0
+        }
       ]);
       setStudentName('');
     }
@@ -138,7 +177,13 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         setError('Please enter names for at least two teams.');
         return;
       }
-      finalParticipants = trimmedTeams.map(t => ({ ...t, attempted: 0, correct: 0 }));
+      finalParticipants = trimmedTeams.map(t => ({
+        ...t,
+        attempted: 0,
+        correct: 0,
+        wordsAttempted: 0,
+        wordsCorrect: 0
+      }));
     } else {
       const trimmedStudents = students
         .map(student => ({ ...student, name: student.name.trim() }))
@@ -147,7 +192,13 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         setError('Please enter names for at least two students.');
         return;
       }
-      finalParticipants = trimmedStudents.map(s => ({ ...s, attempted: 0, correct: 0 }));
+      finalParticipants = trimmedStudents.map(s => ({
+        ...s,
+        attempted: 0,
+        correct: 0,
+        wordsAttempted: 0,
+        wordsCorrect: 0
+      }));
     }
 
     setError('');

--- a/types.ts
+++ b/types.ts
@@ -15,6 +15,8 @@ export interface Participant {
   streak: number;
   attempted: number;
   correct: number;
+  wordsAttempted: number;
+  wordsCorrect: number;
   accuracy?: number;
 }
 


### PR DESCRIPTION
## Summary
- extend participant stats with `wordsAttempted` and `wordsCorrect`
- track these counters on spelling submissions and skips
- show percentage accuracy based on attempted vs correct words on the results screen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afec746dbc8332979c800e660b24b3