### PR TITLE
Add TTS playback and replay button

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -4,6 +4,7 @@ import { GameConfig, Word, Participant, GameResults } from './types';
 import correctSoundFile from './audio/correct.mp3';
 import wrongSoundFile from './audio/wrong.mp3';
 import timeoutSoundFile from './audio/timeout.mp3';
+import { speak } from './utils/tts';
 
 interface GameScreenProps {
   config: GameConfig;
@@ -131,6 +132,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       setExtraAttempt(false);
       setIsHelpOpen(false);
       setLetters(Array.from({ length: nextWord.word.length }, () => ''));
+      speak(nextWord.word);
     } else {
       onEndGameWithMissedWords();
     }
@@ -380,6 +382,12 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
                 {currentWord.word}
               </div>
             )}
+            <button
+              onClick={() => speak(currentWord.word)}
+              className="absolute top-0 left-0 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+            >
+              Replay Word
+            </button>
             <button
               onClick={() => setShowWord(!showWord)}
               className="absolute top-0 right-0 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"

--- a/utils/tts.ts
+++ b/utils/tts.ts
@@ -1,0 +1,7 @@
+export function speak(text: string) {
+  if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+    const utterance = new SpeechSynthesisUtterance(text);
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+  }
+}


### PR DESCRIPTION
## Summary
- add basic Web Speech API TTS utility
- read new word aloud when selected
- allow replaying word audio via button

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afec72e41483328cfd616af03ca283