### PR TITLE
Add help shop hints and starting point

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Transform your spelling lessons into engaging, interactive competitions that stu
 - **Help Shop System** - Strategic point-based assistance options
 - **Incorrect Word Tracking** - Identify challenging words for future lessons
 - **Sound Effects** - Audio feedback for correct/incorrect answers
-- **Dynamic Scoring** - Starting points scale with player count with difficulty multipliers and streak bonuses
+- **Dynamic Scoring** - Players start with 1 point and earn more with difficulty multipliers and streak bonuses
 
 ---
 
@@ -67,13 +67,15 @@ Transform your spelling lessons into engaging, interactive competitions that stu
 
 ## 🛍️ **Strategic Help Shop System**
 
-Students earn points for correct answers and can strategically spend them on assistance:
+Students earn points for correct answers and can strategically spend them on assistance. Players start with 1 point each, allowing immediate use of the shop:
 
 | Help Item | Cost | Description |
 |-----------|------|-------------|
 | 🔍 **Reveal Word** | 3 points | Show the word in large text |
 | ⏱️ **Extra Time** | 2 points | Add 15 seconds to the timer |
-| 📊 **Syllable Count** | 1 point | Audio hint about syllable structure |
+| 📖 **Definition Hint** | 1 point | Provide the word's definition |
+| 🌍 **Origin Hint** | 1 point | Share the word's origin |
+| 📝 **Sentence Hint** | 1 point | Use the word in a sentence |
 
 *This system encourages strategic thinking and resource management while providing scaffolded support.*
 

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -11,7 +11,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     {
       name: 'Team Alpha',
       lives: 5,
-      points: 0,
+      points: 1,
       streak: 0,
       attempted: 0,
       correct: 0,
@@ -21,7 +21,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     {
       name: 'Team Beta',
       lives: 5,
-      points: 0,
+      points: 1,
       streak: 0,
       attempted: 0,
       correct: 0,
@@ -58,7 +58,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
       {
         name: '',
         lives: 5,
-        points: 0,
+        points: 1,
         streak: 0,
         attempted: 0,
         correct: 0,
@@ -84,7 +84,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         {
           name: studentName.trim(),
           lives: 5,
-          points: 0,
+          points: 1,
           streak: 0,
           attempted: 0,
           correct: 0,

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -76,7 +76,7 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
     const [gameMode, setGameMode] = useState("team");
     const handleStart = () => {
         const config = {
-            participants: [{ name: "Team 1", lives: 5, points: 0, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0 }, { name: "Team 2", lives: 5, points: 0, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0 }],
+            participants: [{ name: "Team 1", lives: 5, points: 1, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0 }, { name: "Team 2", lives: 5, points: 1, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0 }],
             gameMode,
             timerDuration: 30,
             skipPenaltyType: 'lives',


### PR DESCRIPTION
## Summary
- expand help shop with definition, origin, and sentence hints that cost one point
- start each participant with one point for immediate shop access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b026c8ce5c8332ba6e40124bdbdc1d