### PR TITLE
Add point-based hint purchases

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -42,7 +42,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const [timeLeft, setTimeLeft] = React.useState(config.timerDuration);
   const isTeamMode = config.gameMode === 'team';
   const [showWord, setShowWord] = React.useState(true);
-  const [showHint, setShowHint] = React.useState(false);
+  const [showDefinition, setShowDefinition] = React.useState(false);
+  const [showOrigin, setShowOrigin] = React.useState(false);
+  const [showSentence, setShowSentence] = React.useState(false);
   const [letters, setLetters] = React.useState<string[]>([]);
   const [feedback, setFeedback] = React.useState<Feedback>({ message: '', type: '' });
   const timerRef = React.useRef<NodeJS.Timeout | null>(null);
@@ -144,7 +146,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       setRevealedLetters(Array.from({ length: nextWord.word.length }, () => false));
       setExtraAttempt(false);
       setIsHelpOpen(false);
-      setShowHint(false);
+      setShowDefinition(false);
+      setShowOrigin(false);
+      setShowSentence(false);
       setLetters(Array.from({ length: nextWord.word.length }, () => ''));
       speak(nextWord.word);
     } else {
@@ -435,25 +439,62 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
                   .join(' ')}
               </p>
             )}
-            {showHint && (
-              <>
-                <p className="text-2xl mb-2">
-                  <strong className="text-yellow-300">Definition:</strong> {currentWord.definition}
-                </p>
-                <p className="text-xl mb-2">
-                  <strong className="text-yellow-300">Origin:</strong> {currentWord.origin}
-                </p>
-                <p className="text-xl">
-                  <strong className="text-yellow-300">Example:</strong> "{currentWord.example}"
-                </p>
-              </>
+            {showDefinition && (
+              <p className="text-2xl mb-2">
+                <strong className="text-yellow-300">Definition:</strong> {currentWord.definition}
+              </p>
             )}
-            <button
-              onClick={() => setShowHint(!showHint)}
-              className="mt-4 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
-            >
-              {showHint ? 'Hide Hint' : 'Show Hint'}
-            </button>
+            {showOrigin && (
+              <p className="text-xl mb-2">
+                <strong className="text-yellow-300">Origin:</strong> {currentWord.origin}
+              </p>
+            )}
+            {showSentence && (
+              <p className="text-xl">
+                <strong className="text-yellow-300">Example:</strong> "{currentWord.example}"
+              </p>
+            )}
+            <div className="mt-4 flex gap-4 justify-center">
+              {!showDefinition && (
+                <button
+                  onClick={() => {
+                    if (participants[currentParticipantIndex].points < 1) return;
+                    spendPoints(currentParticipantIndex, 1);
+                    setShowDefinition(true);
+                  }}
+                  disabled={participants[currentParticipantIndex].points < 1}
+                  className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold disabled:opacity-50"
+                >
+                  Buy Definition (-1)
+                </button>
+              )}
+              {!showOrigin && (
+                <button
+                  onClick={() => {
+                    if (participants[currentParticipantIndex].points < 1) return;
+                    spendPoints(currentParticipantIndex, 1);
+                    setShowOrigin(true);
+                  }}
+                  disabled={participants[currentParticipantIndex].points < 1}
+                  className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold disabled:opacity-50"
+                >
+                  Buy Origin (-1)
+                </button>
+              )}
+              {!showSentence && (
+                <button
+                  onClick={() => {
+                    if (participants[currentParticipantIndex].points < 1) return;
+                    spendPoints(currentParticipantIndex, 1);
+                    setShowSentence(true);
+                  }}
+                  disabled={participants[currentParticipantIndex].points < 1}
+                  className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold disabled:opacity-50"
+                >
+                  Buy Sentence (-1)
+                </button>
+              )}
+            </div>
           </div>
           <div className="flex gap-2 justify-center mb-4">
             {letters.map((letter, idx) => (


### PR DESCRIPTION
## Summary
- Add independent hint flags for definition, origin, and sentence
- Allow players to spend points to reveal hints, deducting one point each
- Reset hint flags on new words

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b026c524788332bbaaf6fada71a9f1