### PR TITLE
Add on-screen keyboard for spelling

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -6,6 +6,7 @@ import wrongSoundFile from './audio/wrong.mp3';
 import timeoutSoundFile from './audio/timeout.mp3';
 import { launchConfetti } from './utils/confetti';
 import { speak } from './utils/tts';
+import OnScreenKeyboard from './components/OnScreenKeyboard';
 
 interface GameScreenProps {
   config: GameConfig;
@@ -253,6 +254,27 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     spendPoints(currentParticipantIndex, cost);
     setExtraAttempt(true);
     setUsedHint(true);
+  };
+
+  const handleVirtualLetter = (letter: string) => {
+    setLetters(prev => {
+      const index = prev.findIndex(l => l === '');
+      if (index === -1) return prev;
+      const newLetters = [...prev];
+      newLetters[index] = letter;
+      return newLetters;
+    });
+  };
+
+  const handleVirtualBackspace = () => {
+    setLetters(prev => {
+      const reverseIndex = [...prev].reverse().findIndex(l => l !== '');
+      if (reverseIndex === -1) return prev;
+      const index = prev.length - 1 - reverseIndex;
+      const newLetters = [...prev];
+      newLetters[index] = '';
+      return newLetters;
+    });
   };
 
   const handleSpellingSubmit = () => {
@@ -540,14 +562,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
               </div>
             ))}
           </div>
-          <div className="flex gap-4 justify-center">
-            <button
-              onClick={handleSpellingSubmit}
-              className="bg-green-500 hover:bg-green-600 text-white px-8 py-4 rounded-lg text-2xl font-bold"
-            >
-              Submit
-            </button>
-          </div>
+          <OnScreenKeyboard
+            onLetter={handleVirtualLetter}
+            onBackspace={handleVirtualBackspace}
+            onSubmit={handleSpellingSubmit}
+          />
 
           <div className="mt-6 flex justify-center gap-4">
             <button

--- a/components/OnScreenKeyboard.tsx
+++ b/components/OnScreenKeyboard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface OnScreenKeyboardProps {
+  onLetter: (letter: string) => void;
+  onBackspace: () => void;
+  onSubmit: () => void;
+}
+
+const letters = Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i));
+
+const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({ onLetter, onBackspace, onSubmit }) => {
+  return (
+    <div className="flex flex-wrap justify-center gap-2 mt-4">
+      {letters.map(letter => (
+        <button
+          key={letter}
+          onClick={() => onLetter(letter.toLowerCase())}
+          className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+        >
+          {letter}
+        </button>
+      ))}
+      <button
+        onClick={onBackspace}
+        className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+      >
+        Backspace
+      </button>
+      <button
+        onClick={onSubmit}
+        className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg font-bold"
+      >
+        Submit
+      </button>
+    </div>
+  );
+};
+
+export default OnScreenKeyboard;


### PR DESCRIPTION
## Summary
- Add reusable OnScreenKeyboard component with letters, Backspace, and Submit
- Display on-screen keyboard in GameScreen to update letters and send guesses
- Preserve existing hardware keyboard input handling

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_68b06819c8ac8332b89ec19b8db1c536