### PR TITLE
Initialize bulk students with one point

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -129,7 +129,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     const newStudents = uniqueNames.map(name => ({
       name,
       lives: 5,
-      points: 0,
+      points: 1,
       streak: 0,
       attempted: 0,
       correct: 0,


### PR DESCRIPTION
## Summary
- Start bulk-added students with 1 point instead of 0.
- Ensure `handleStart` preserves existing participant points when starting a game.

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'esbuild'; dependency installation blocked with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b06843b8d08332a790e36f92328518