### PR TITLE
Add prefix and suffix hint features

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -43,9 +43,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const [showWord, setShowWord] = React.useState(true);
   const [showHint, setShowHint] = React.useState(false);
   const [usedHint, setUsedHint] = React.useState(false);
-  const [showDefinition, setShowDefinition] = React.useState(false);
-  const [showOrigin, setShowOrigin] = React.useState(false);
-  const [showSentence, setShowSentence] = React.useState(false);
+    const [showDefinition, setShowDefinition] = React.useState(false);
+    const [showOrigin, setShowOrigin] = React.useState(false);
+    const [showSentence, setShowSentence] = React.useState(false);
+    const [showPrefix, setShowPrefix] = React.useState(false);
+    const [showSuffix, setShowSuffix] = React.useState(false);
   const [letters, setLetters] = React.useState<string[]>([]);
   const [feedback, setFeedback] = React.useState<Feedback>({ message: '', type: '' });
   const timerRef = React.useRef<NodeJS.Timeout | null>(null);
@@ -149,9 +151,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       setIsHelpOpen(false);
       setShowHint(false);
       setUsedHint(false);
-      setShowDefinition(false);
-      setShowOrigin(false);
-      setShowSentence(false);
+        setShowDefinition(false);
+        setShowOrigin(false);
+        setShowSentence(false);
+        setShowPrefix(false);
+        setShowSuffix(false);
       setLetters(Array.from({ length: nextWord.word.length }, () => ''));
       speak(nextWord.word);
     } else {
@@ -247,13 +251,29 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     setRevealedLetters(newRevealed);
   };
 
-  const handleFriendSubstitution = () => {
-    const cost = 4;
-    if (participants[currentParticipantIndex].points < cost) return;
-    spendPoints(currentParticipantIndex, cost);
-    setExtraAttempt(true);
-    setUsedHint(true);
-  };
+    const handleFriendSubstitution = () => {
+      const cost = 4;
+      if (participants[currentParticipantIndex].points < cost) return;
+      spendPoints(currentParticipantIndex, cost);
+      setExtraAttempt(true);
+      setUsedHint(true);
+    };
+
+    const handlePrefixReveal = () => {
+      const cost = 3;
+      if (participants[currentParticipantIndex].points < cost || !currentWord) return;
+      spendPoints(currentParticipantIndex, cost);
+      setUsedHint(true);
+      setShowPrefix(true);
+    };
+
+    const handleSuffixReveal = () => {
+      const cost = 3;
+      if (participants[currentParticipantIndex].points < cost || !currentWord) return;
+      spendPoints(currentParticipantIndex, cost);
+      setUsedHint(true);
+      setShowSuffix(true);
+    };
 
   const handleSpellingSubmit = () => {
     if (!currentWord) return;
@@ -477,15 +497,25 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
                 <strong className="text-yellow-300">Origin:</strong> {currentWord.origin}
               </p>
             )}
-            {showSentence && (
-              <p className="text-xl">
-                <strong className="text-yellow-300">Example:</strong> "{currentWord.example}"
-              </p>
-            )}
-            <div className="mt-4 flex gap-4 justify-center">
-              {!showDefinition && (
-                <button
-                  onClick={() => {
+              {showSentence && (
+                <p className="text-xl">
+                  <strong className="text-yellow-300">Example:</strong> "{currentWord.example}"
+                </p>
+              )}
+              {showPrefix && showWord && currentWord.prefix && (
+                <p className="text-xl mb-2">
+                  <strong className="text-yellow-300">Prefix:</strong> {currentWord.prefix}
+                </p>
+              )}
+              {showSuffix && showWord && currentWord.suffix && (
+                <p className="text-xl mb-2">
+                  <strong className="text-yellow-300">Suffix:</strong> {currentWord.suffix}
+                </p>
+              )}
+              <div className="mt-4 flex gap-4 justify-center">
+                {!showDefinition && (
+                  <button
+                    onClick={() => {
                     if (participants[currentParticipantIndex].points < 1) return;
                     spendPoints(currentParticipantIndex, 1);
                     setShowDefinition(true);
@@ -520,6 +550,26 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
                   className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold disabled:opacity-50"
                 >
                   Buy Sentence (-1)
+                </button>
+              )}
+            </div>
+            <div className="mt-4 flex gap-4 justify-center">
+              {!showPrefix && currentWord.prefix && (
+                <button
+                  onClick={handlePrefixReveal}
+                  disabled={participants[currentParticipantIndex].points < 3}
+                  className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold disabled:opacity-50"
+                >
+                  Reveal Prefix (-3)
+                </button>
+              )}
+              {!showSuffix && currentWord.suffix && (
+                <button
+                  onClick={handleSuffixReveal}
+                  disabled={participants[currentParticipantIndex].points < 3}
+                  className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold disabled:opacity-50"
+                >
+                  Reveal Suffix (-3)
                 </button>
               )}
             </div>

--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ open index.html
      "syllables": "ex-am-ple (3 syllables)",
      "definition": "A thing characteristic of its kind",
      "origin": "Latin 'exemplum' meaning sample",
-     "example": "This is a good example of the format.",
-     "prefixSuffix": "Base word with no prefix or suffix",
-     "pronunciation": "ig-ZAM-pul"
+      "example": "This is a good example of the format.",
+      "prefix": "",
+      "suffix": "",
+      "pronunciation": "ig-ZAM-pul"
    }
    ```
 

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -494,7 +494,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
           <div className="mt-4 text-sm text-gray-300">
             <p>
               <strong>Format:</strong> The first row should be headers: `word`, `syllables`, `definition`, `origin`, `example`,
-              `prefixSuffix`, `pronunciation`. The difficulty will be determined by word length.
+              `prefix`, `suffix`, `pronunciation`. The difficulty will be determined by word length.
             </p>
           </div>
         </div>

--- a/dist/app.js
+++ b/dist/app.js
@@ -351,7 +351,7 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
                         </div>
                     </div>
                     <div className="mt-4 text-sm text-gray-300">
-                        <p><strong>Format:</strong> The first row should be headers: `word`, `syllables`, `definition`, `origin`, `sentence`, `prefixSuffix`, `pronunciation`. The difficulty will be determined by word length.</p>
+                        <p><strong>Format:</strong> The first row should be headers: `word`, `syllables`, `definition`, `origin`, `sentence`, `prefix`, `suffix`, `pronunciation`. The difficulty will be determined by word length.</p>
                     </div>
                 </div>
 
@@ -412,7 +412,8 @@ const GameScreen = ({ config, onEndGame }) => {
     const [isHelpOpen, setIsHelpOpen] = useState(false);
     const [revealedHints, setRevealedHints] = useState({
         syllables: false,
-        prefixSuffix: false,
+        prefix: false,
+        suffix: false,
         pronunciation: false
     });
 
@@ -472,7 +473,7 @@ const GameScreen = ({ config, onEndGame }) => {
             setRevealedLetters(Array.from({ length: nextWord.word.length }, () => false));
             setExtraAttempt(false);
             setIsHelpOpen(false);
-            setRevealedHints({ syllables: false, prefixSuffix: false, pronunciation: false });
+            setRevealedHints({ syllables: false, prefix: false, suffix: false, pronunciation: false });
         } else {
             onEndGameWithMissedWords();
         }
@@ -579,11 +580,18 @@ const GameScreen = ({ config, onEndGame }) => {
         setRevealedHints((prev) => ({ ...prev, syllables: true }));
     };
 
-    const handleRevealPrefixSuffix = () => {
-        const cost = 2;
+    const handleRevealPrefix = () => {
+        const cost = 3;
         if (currentParticipant.points < cost || !currentWord) return;
         spendPoints(currentParticipantIndex, cost);
-        setRevealedHints((prev) => ({ ...prev, prefixSuffix: true }));
+        setRevealedHints((prev) => ({ ...prev, prefix: true }));
+    };
+
+    const handleRevealSuffix = () => {
+        const cost = 3;
+        if (currentParticipant.points < cost || !currentWord) return;
+        spendPoints(currentParticipantIndex, cost);
+        setRevealedHints((prev) => ({ ...prev, suffix: true }));
     };
 
     const handleRevealPronunciation = () => {
@@ -726,8 +734,11 @@ const GameScreen = ({ config, onEndGame }) => {
                         {revealedHints.syllables && (
                             <p className="text-xl mb-2"><strong className="text-yellow-300">Syllables:</strong> {currentWord.syllables}</p>
                         )}
-                        {revealedHints.prefixSuffix && (
-                            <p className="text-xl mb-2"><strong className="text-yellow-300">Prefix/Suffix:</strong> {currentWord.prefixSuffix}</p>
+                        {showWord && revealedHints.prefix && (
+                            <p className="text-xl mb-2"><strong className="text-yellow-300">Prefix:</strong> {currentWord.prefix}</p>
+                        )}
+                        {showWord && revealedHints.suffix && (
+                            <p className="text-xl mb-2"><strong className="text-yellow-300">Suffix:</strong> {currentWord.suffix}</p>
                         )}
                         {revealedHints.pronunciation && (
                             <p className="text-xl"><strong className="text-yellow-300">Pronunciation:</strong> {currentWord.pronunciation}</p>
@@ -792,11 +803,18 @@ const GameScreen = ({ config, onEndGame }) => {
                             Reveal Syllables (-2)
                         </button>
                         <button
-                            onClick={handleRevealPrefixSuffix}
-                            disabled={revealedHints.prefixSuffix || currentParticipant.points < 2}
+                            onClick={handleRevealPrefix}
+                            disabled={revealedHints.prefix || currentParticipant.points < 3}
                             className="w-full bg-teal-500 hover:bg-teal-600 text-white px-4 py-2 rounded disabled:opacity-50"
                         >
-                            Reveal Prefix/Suffix (-2)
+                            Reveal Prefix (-3)
+                        </button>
+                        <button
+                            onClick={handleRevealSuffix}
+                            disabled={revealedHints.suffix || currentParticipant.points < 3}
+                            className="w-full bg-teal-500 hover:bg-teal-600 text-white px-4 py-2 rounded disabled:opacity-50"
+                        >
+                            Reveal Suffix (-3)
                         </button>
                         <button
                             onClick={handleRevealPronunciation}

--- a/dist/wordlists/example.csv
+++ b/dist/wordlists/example.csv
@@ -1,3 +1,3 @@
-word,syllables,definition,origin,example,prefixSuffix,pronunciation
-apple,ap-ple,a fruit,Old English,She ate an apple.,,AP-uhl
-banana,ba-na-na,another fruit,Wolof,Bananas are yellow.,,buh-NA-nuh
+word,syllables,definition,origin,example,prefix,suffix,pronunciation
+apple,ap-ple,a fruit,Old English,She ate an apple.,,,AP-uhl
+banana,ba-na-na,another fruit,Wolof,Bananas are yellow.,,,buh-NA-nuh

--- a/dist/wordlists/example.json
+++ b/dist/wordlists/example.json
@@ -5,7 +5,8 @@
     "definition": "a fruit",
     "origin": "Old English",
     "example": "She ate an apple.",
-    "prefixSuffix": "",
+    "prefix": "",
+    "suffix": "",
     "pronunciation": "AP-uhl"
   },
   {
@@ -14,7 +15,8 @@
     "definition": "another fruit",
     "origin": "Wolof",
     "example": "Bananas are yellow.",
-    "prefixSuffix": "",
+    "prefix": "",
+    "suffix": "",
     "pronunciation": "buh-NA-nuh"
   }
 ]

--- a/dist/wordlists/example.tsv
+++ b/dist/wordlists/example.tsv
@@ -1,3 +1,3 @@
-word    syllables   definition  origin  example  prefixSuffix   pronunciation
-apple   ap-ple  a fruit   Old English   She ate an apple.   AP-uhl
-banana  ba-na-na    another fruit   Wolof   Bananas are yellow.   buh-NA-nuh
+word	syllables	definition	origin	example	prefix	suffix	pronunciation
+apple	ap-ple	a fruit	Old English	She ate an apple.			AP-uhl
+banana	ba-na-na	another fruit	Wolof	Bananas are yellow.			buh-NA-nuh

--- a/dist/words.json
+++ b/dist/words.json
@@ -6,7 +6,8 @@
       "definition": "A person you like and know well",
       "origin": "Old English 'freond', from Germanic root meaning 'to love'",
       "example": "My best friend and I love to play together.",
-      "prefixSuffix": "Base word with no prefix or suffix",
+      "prefix": "",
+      "suffix": "",
       "pronunciation": "FREND"
     },
     {
@@ -15,7 +16,8 @@
       "definition": "Feeling or showing pleasure and contentment",
       "origin": "Middle English 'happy', from 'hap' meaning luck or fortune",
       "example": "The children were happy to see the circus.",
-      "prefixSuffix": "Base word 'hap' + suffix '-py'",
+      "prefix": "hap",
+      "suffix": "py",
       "pronunciation": "HAP-ee"
     }
   ],
@@ -26,7 +28,8 @@
       "definition": "Required to be done or achieved; essential",
       "origin": "Latin 'necessarius', from 'necesse' meaning unavoidable",
       "example": "It is necessary to study hard for the test.",
-      "prefixSuffix": "Base 'necess' + suffix '-ary'",
+      "prefix": "necess",
+      "suffix": "ary",
       "pronunciation": "NES-uh-ser-ee"
     }
   ],
@@ -37,7 +40,8 @@
       "definition": "A type of flower with many thin petals",
       "origin": "Greek 'chrysos' (gold) + 'anthemon' (flower)",
       "example": "The chrysanthemum bloomed beautifully in autumn.",
-      "prefixSuffix": "Greek compound: chryso- (gold) + -anthemum (flower)",
+      "prefix": "chryso",
+      "suffix": "anthemum",
       "pronunciation": "kri-SAN-thuh-mum"
     }
   ]

--- a/types.ts
+++ b/types.ts
@@ -4,7 +4,8 @@ export interface Word {
   definition: string;
   origin: string;
   example: string;
-  prefixSuffix?: string;
+  prefix?: string;
+  suffix?: string;
   pronunciation?: string;
 }
 

--- a/wordlists/example.csv
+++ b/wordlists/example.csv
@@ -1,3 +1,3 @@
-word,syllables,definition,origin,example,prefixSuffix,pronunciation
-apple,ap-ple,a fruit,Old English,She ate an apple.,,AP-uhl
-banana,ba-na-na,another fruit,Wolof,Bananas are yellow.,,buh-NA-nuh
+word,syllables,definition,origin,example,prefix,suffix,pronunciation
+apple,ap-ple,a fruit,Old English,She ate an apple.,,,AP-uhl
+banana,ba-na-na,another fruit,Wolof,Bananas are yellow.,,,buh-NA-nuh

--- a/wordlists/example.json
+++ b/wordlists/example.json
@@ -5,7 +5,8 @@
     "definition": "a fruit",
     "origin": "Old English",
     "example": "She ate an apple.",
-    "prefixSuffix": "",
+    "prefix": "",
+    "suffix": "",
     "pronunciation": "AP-uhl"
   },
   {
@@ -14,7 +15,8 @@
     "definition": "another fruit",
     "origin": "Wolof",
     "example": "Bananas are yellow.",
-    "prefixSuffix": "",
+    "prefix": "",
+    "suffix": "",
     "pronunciation": "buh-NA-nuh"
   }
 ]

--- a/wordlists/example.tsv
+++ b/wordlists/example.tsv
@@ -1,3 +1,3 @@
-word    syllables   definition  origin  example  prefixSuffix   pronunciation
-apple   ap-ple  a fruit   Old English   She ate an apple.   AP-uhl
-banana  ba-na-na    another fruit   Wolof   Bananas are yellow.   buh-NA-nuh
+word	syllables	definition	origin	example	prefix	suffix	pronunciation
+apple	ap-ple	a fruit	Old English	She ate an apple.			AP-uhl
+banana	ba-na-na	another fruit	Wolof	Bananas are yellow.			buh-NA-nuh

--- a/words.json
+++ b/words.json
@@ -6,7 +6,8 @@
       "definition": "A person you like and know well",
       "origin": "Old English 'freond', from Germanic root meaning 'to love'",
       "example": "My best friend and I love to play together.",
-      "prefixSuffix": "Base word with no prefix or suffix",
+      "prefix": "",
+      "suffix": "",
       "pronunciation": "FREND"
     },
     {
@@ -15,7 +16,8 @@
       "definition": "Feeling or showing pleasure and contentment",
       "origin": "Middle English 'happy', from 'hap' meaning luck or fortune",
       "example": "The children were happy to see the circus.",
-      "prefixSuffix": "Base word 'hap' + suffix '-py'",
+      "prefix": "hap",
+      "suffix": "py",
       "pronunciation": "HAP-ee"
     }
   ],
@@ -26,7 +28,8 @@
       "definition": "Required to be done or achieved; essential",
       "origin": "Latin 'necessarius', from 'necesse' meaning unavoidable",
       "example": "It is necessary to study hard for the test.",
-      "prefixSuffix": "Base 'necess' + suffix '-ary'",
+      "prefix": "necess",
+      "suffix": "ary",
       "pronunciation": "NES-uh-ser-ee"
     }
   ],
@@ -37,7 +40,8 @@
       "definition": "A type of flower with many thin petals",
       "origin": "Greek 'chrysos' (gold) + 'anthemon' (flower)",
       "example": "The chrysanthemum bloomed beautifully in autumn.",
-      "prefixSuffix": "Greek compound: chryso- (gold) + -anthemum (flower)",
+      "prefix": "chryso",
+      "suffix": "anthemum",
       "pronunciation": "kri-SAN-thuh-mum"
     }
   ]


### PR DESCRIPTION
## Summary
- Switch word type to separate `prefix` and `suffix` fields and update bundled word lists
- Add prefix and suffix reveal hints to the game, costing 3 points each and hidden when the word is concealed
- Document new fields in setup instructions and README

## Testing
- `npm install` *(fails: 403 Forbidden fetching canvas-confetti)*
- `npm test`
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_68b06a1ff2c883329040210bc3efd334