### PR TITLE
Enhance leaderboard with medals and avatars

### DIFF
--- a/LeaderboardScreen.tsx
+++ b/LeaderboardScreen.tsx
@@ -28,15 +28,27 @@ const LeaderboardScreen: React.FC<LeaderboardScreenProps> = ({ onBack }) => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white text-center flex flex-col items-center justify-center">
-      <h1 className="text-6xl font-bold mb-8 text-yellow-300">Leaderboard</h1>
+      <h1 className="text-6xl font-bold mb-8 text-yellow-300">🏅 Leaderboard</h1>
       <div className="bg-white/10 p-8 rounded-lg w-full max-w-md">
         {entries.length === 0 ? (
           <div className="text-xl">No scores yet.</div>
         ) : (
           <ol className="text-xl space-y-2">
             {entries.map((entry, index) => (
-              <li key={index} className="flex justify-between py-1">
-                <span className="font-bold">{index + 1}. {entry.name}</span>
+              <li key={index} className="flex justify-between items-center py-1">
+                <span className="flex items-center font-bold">
+                  {index < 3 && <span className="mr-2">{['🥇', '🥈', '🥉'][index]}</span>}
+                  {entry.avatar ? (
+                    <img
+                      src={entry.avatar}
+                      alt={`${entry.name}'s avatar`}
+                      className="w-6 h-6 rounded-full mr-2"
+                    />
+                  ) : (
+                    <div className="w-6 h-6 rounded-full bg-gray-500 mr-2" />
+                  )}
+                  {index + 1}. {entry.name}
+                </span>
                 <span className="text-yellow-300">{entry.score}</span>
               </li>
             ))}

--- a/types.ts
+++ b/types.ts
@@ -52,4 +52,5 @@ export interface LeaderboardEntry {
   name: string;
   score: number;
   date: string;
+  avatar?: string;
 }


### PR DESCRIPTION
## Summary
- Show medal emojis for top-three leaderboard entries
- Add 🏅 badge to Leaderboard heading
- Support optional player avatars via `avatar` field

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'esbuild')*


------
https://chatgpt.com/codex/tasks/task_e_68b06ca39c44833282ee1f7f529eb77a