### PR TITLE
feat: add sound hook and persistent mute toggle

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -10,6 +10,7 @@ import shopSoundFile from './audio/shop.mp3';
 import loseLifeSoundFile from './audio/lose-life.mp3';
 import { launchConfetti } from './utils/confetti';
 import { speak } from './utils/tts';
+import useSound from './utils/useSound';
 import OnScreenKeyboard from './components/OnScreenKeyboard';
 
 // Interface definitions remain the same...
@@ -55,13 +56,13 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const [isHelpOpen, setIsHelpOpen] = React.useState(false);
   const [isPaused, setIsPaused] = React.useState(false);
 
-  const correctAudio = React.useRef<HTMLAudioElement>(new Audio(correctSoundFile));
-  const wrongAudio = React.useRef<HTMLAudioElement>(new Audio(wrongSoundFile));
-  const timeoutAudio = React.useRef<HTMLAudioElement>(new Audio(timeoutSoundFile));
-  const letterCorrectAudio = React.useRef<HTMLAudioElement>(new Audio(letterCorrectSoundFile));
-  const letterWrongAudio = React.useRef<HTMLAudioElement>(new Audio(letterWrongSoundFile));
-  const shopAudio = React.useRef<HTMLAudioElement>(new Audio(shopSoundFile));
-  const loseLifeAudio = React.useRef<HTMLAudioElement>(new Audio(loseLifeSoundFile));
+  const playCorrect = useSound(correctSoundFile, config.soundEnabled);
+  const playWrong = useSound(wrongSoundFile, config.soundEnabled);
+  const playTimeout = useSound(timeoutSoundFile, config.soundEnabled);
+  const playLetterCorrect = useSound(letterCorrectSoundFile, config.soundEnabled);
+  const playLetterWrong = useSound(letterWrongSoundFile, config.soundEnabled);
+  const playShop = useSound(shopSoundFile, config.soundEnabled);
+  const playLoseLife = useSound(loseLifeSoundFile, config.soundEnabled);
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
 
   const shuffleArray = (arr: Word[]) => [...arr].sort(() => Math.random() - 0.5);
@@ -81,10 +82,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     timerRef.current = setInterval(() => {
       setTimeLeft(prevTime => {
         if (prevTime <= 1) {
-          if (config.soundEnabled) {
-            timeoutAudio.current.currentTime = 0;
-            timeoutAudio.current.play();
-          }
+          playTimeout();
           clearInterval(timerRef.current as NodeJS.Timeout);
           handleIncorrectAttempt();
           return 0;
@@ -208,10 +206,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     });
     setParticipants(updatedParticipants);
 
-    if (config.soundEnabled) {
-      loseLifeAudio.current.currentTime = 0;
-      loseLifeAudio.current.play();
-    }
+    playLoseLife();
     if (currentWord) setLetters(Array(currentWord.word.length).fill(''));
 
     const newAttempted = new Set(attemptedParticipants);
@@ -245,10 +240,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
         return p;
       })
     );
-    if (config.soundEnabled) {
-      shopAudio.current.currentTime = 0;
-      shopAudio.current.play();
-    }
+    playShop();
   };
 
   const handleHangmanReveal = () => {
@@ -316,12 +308,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       if (index === -1) return prev;
       const newLetters = [...prev];
       newLetters[index] = letter;
-      if (config.soundEnabled) {
-        const isCorrectLetter = currentWord.word[index].toLowerCase() === letter.toLowerCase();
-        const audio = isCorrectLetter ? letterCorrectAudio.current : letterWrongAudio.current;
-        audio.currentTime = 0;
-        audio.play();
-      }
+      const isCorrectLetter = currentWord.word[index].toLowerCase() === letter.toLowerCase();
+      const play = isCorrectLetter ? playLetterCorrect : playLetterWrong;
+      play();
       return newLetters;
     });
   };
@@ -372,10 +361,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     setParticipants(updatedParticipants);
 
     if (isCorrect) {
-      if (config.soundEnabled) {
-        correctAudio.current.currentTime = 0;
-        correctAudio.current.play();
-      }
+      playCorrect();
       if (config.effectsEnabled) {
         launchConfetti();
       }
@@ -388,10 +374,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
         nextTurn();
       }, 2000);
     } else {
-      if (config.soundEnabled) {
-        wrongAudio.current.currentTime = 0;
-        wrongAudio.current.play();
-      }
+      playWrong();
       handleIncorrectAttempt();
     }
   };
@@ -414,9 +397,8 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     });
     setParticipants(updatedParticipants);
 
-    if (isLivesPenalty && config.soundEnabled) {
-      loseLifeAudio.current.currentTime = 0;
-      loseLifeAudio.current.play();
+    if (isLivesPenalty) {
+      playLoseLife();
     }
     setFeedback({ message: `Word Skipped (${deduction})`, type: 'info' });
     if (currentWord) {
@@ -688,6 +670,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
             onLetter={handleVirtualLetter}
             onBackspace={handleVirtualBackspace}
             onSubmit={handleSpellingSubmit}
+            soundEnabled={config.soundEnabled}
           />
 
           <div className="mt-6 flex justify-center gap-4">

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -53,7 +53,10 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [bulkStudentError, setBulkStudentError] = useState('');
   const [skipPenaltyType, setSkipPenaltyType] = useState<'lives' | 'points'>('lives');
   const [skipPenaltyValue, setSkipPenaltyValue] = useState(1);
-  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [soundEnabled, setSoundEnabled] = useState<boolean>(() => {
+    const saved = localStorage.getItem('soundEnabled');
+    return saved !== null ? saved === 'true' : true;
+  });
   const [effectsEnabled, setEffectsEnabled] = useState(true);
   const [initialDifficulty, setInitialDifficulty] = useState(0);
   const [progressionSpeed, setProgressionSpeed] = useState(1);
@@ -72,6 +75,10 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
       } catch {}
     }
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('soundEnabled', String(soundEnabled));
+  }, [soundEnabled]);
 
   const updateTeams = (newTeams: Participant[]) => {
     setTeams(newTeams);

--- a/components/OnScreenKeyboard.tsx
+++ b/components/OnScreenKeyboard.tsx
@@ -1,34 +1,48 @@
 import React from 'react';
+import useSound from '../utils/useSound';
+import letterSoundFile from '../audio/letter-correct.mp3';
 
 interface OnScreenKeyboardProps {
   onLetter: (letter: string) => void;
   onBackspace: () => void;
   onSubmit: () => void;
+  soundEnabled: boolean;
 }
 
 const letters = Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i));
 
-const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({ onLetter, onBackspace, onSubmit }) => {
+const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({ onLetter, onBackspace, onSubmit, soundEnabled }) => {
+  const playKey = useSound(letterSoundFile, soundEnabled);
+
   return (
     <div className="flex flex-wrap justify-center gap-2 mt-4">
       {letters.map(letter => (
         <button
           key={letter}
-          onClick={() => onLetter(letter.toLowerCase())}
+          onClick={() => {
+            playKey();
+            onLetter(letter.toLowerCase());
+          }}
           className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
         >
           {letter}
         </button>
       ))}
       <button
-        onClick={onBackspace}
+        onClick={() => {
+          playKey();
+          onBackspace();
+        }}
         className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
         aria-label="Backspace"
       >
         <span aria-hidden="true">⌫</span>
       </button>
       <button
-        onClick={onSubmit}
+        onClick={() => {
+          playKey();
+          onSubmit();
+        }}
         className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg font-bold"
         aria-label="Submit"
       >

--- a/utils/useSound.ts
+++ b/utils/useSound.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+/**
+ * React hook to load and play an audio clip.
+ * @param src Path to the audio file
+ * @param enabled Whether audio should play
+ * @returns Function to trigger the sound
+ */
+const useSound = (src: string, enabled: boolean = true) => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    audioRef.current = new Audio(src);
+  }, [src]);
+
+  const play = useCallback(() => {
+    if (!enabled || !audioRef.current) return;
+    audioRef.current.currentTime = 0;
+    audioRef.current.play();
+  }, [enabled]);
+
+  return play;
+};
+
+export default useSound;


### PR DESCRIPTION
## Summary
- introduce `useSound` hook to manage audio playback
- trigger hook for letters, correct answers, shop spends, and losing lives
- persist sound preference from setup screen

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_68b071de84648332a54218519a2ba568