### PR TITLE
Add achievements system with badges

### DIFF
--- a/AchievementsScreen.tsx
+++ b/AchievementsScreen.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { defaultAchievements } from './types';
+
+interface AchievementsScreenProps {
+  onBack: () => void;
+}
+
+const AchievementsScreen: React.FC<AchievementsScreenProps> = ({ onBack }) => {
+  const unlocked = React.useMemo(() => {
+    if (typeof window === 'undefined') return [] as string[];
+    try {
+      return JSON.parse(localStorage.getItem('unlockedAchievements') || '[]');
+    } catch {
+      return [];
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-600 to-teal-800 p-8 text-white">
+      <h1 className="text-4xl text-center mb-8">Achievements</h1>
+      <div className="grid gap-6 max-w-xl mx-auto">
+        {defaultAchievements.map(ach => {
+          const earned = unlocked.includes(ach.id);
+          return (
+            <div
+              key={ach.id}
+              className={`flex items-center gap-4 p-4 rounded-lg ${earned ? 'bg-white/20' : 'bg-white/5 opacity-50'}`}
+            >
+              <span className="text-3xl">{ach.icon}</span>
+              <div>
+                <div className="font-bold text-xl">{ach.name}</div>
+                <div className="text-sm">{ach.description}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <button
+        onClick={onBack}
+        className="mt-8 block mx-auto bg-yellow-300 text-black px-6 py-3 rounded-lg font-bold"
+      >
+        Back
+      </button>
+    </div>
+  );
+};
+
+export default AchievementsScreen;
+

--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SkipForward } from 'lucide-react';
-import { GameConfig, Word, Participant, GameResults } from './types';
+import { GameConfig, Word, Participant, GameResults, defaultAchievements } from './types';
 import correctSoundFile from './audio/correct.mp3';
 import wrongSoundFile from './audio/wrong.mp3';
 import timeoutSoundFile from './audio/timeout.mp3';
@@ -76,6 +76,15 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   );
   const [attemptedParticipants, setAttemptedParticipants] = React.useState<Set<number>>(new Set());
   const [missedWords, setMissedWords] = React.useState<Word[]>([]);
+  const [unlockedAchievements, setUnlockedAchievements] = React.useState<string[]>(() => {
+    if (typeof window === 'undefined') return [];
+    try {
+      return JSON.parse(localStorage.getItem('unlockedAchievements') || '[]');
+    } catch {
+      return [];
+    }
+  });
+  const [toast, setToast] = React.useState('');
 
   const startTimer = () => {
     timerRef.current = setInterval(() => {
@@ -372,6 +381,18 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     setParticipants(updatedParticipants);
 
     if (isCorrect) {
+      const participant = updatedParticipants[currentParticipantIndex];
+      const newlyUnlocked = defaultAchievements.filter(
+        ach => participant.wordsCorrect >= ach.threshold && !unlockedAchievements.includes(ach.id)
+      );
+      if (newlyUnlocked.length > 0) {
+        const updatedUnlocked = [...unlockedAchievements, ...newlyUnlocked.map(a => a.id)];
+        setUnlockedAchievements(updatedUnlocked);
+        localStorage.setItem('unlockedAchievements', JSON.stringify(updatedUnlocked));
+        const first = newlyUnlocked[0];
+        setToast(`Achievement unlocked: ${first.icon} ${first.name}!`);
+        setTimeout(() => setToast(''), 3000);
+      }
       if (config.soundEnabled) {
         correctAudio.current.currentTime = 0;
         correctAudio.current.play();
@@ -476,6 +497,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
         className="absolute opacity-0 pointer-events-none"
         aria-hidden="true"
       />
+      {toast && (
+        <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-lg z-50">
+          {toast}
+        </div>
+      )}
       <div className="absolute top-8 left-8 flex gap-8">
         {participants.map((p, index) => (
           <div key={index} className="text-center">

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import { Users, BookOpen, Play, Volume2, Globe, RotateCcw, SkipForward } from 'lucide-react';
 import LeaderboardScreen from './LeaderboardScreen';
+import AchievementsScreen from './AchievementsScreen';
 
 // --- Main App Component ---
 const SpellingBeeGame = () => {
@@ -50,12 +51,16 @@ const SpellingBeeGame = () => {
         setGameState("leaderboard");
     };
 
+    const handleViewAchievements = () => {
+        setGameState("achievements");
+    };
+
     const handleBackToSetup = () => {
         setGameState("setup");
     };
 
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} />;
+        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
     }
     if (gameState === "playing") {
         return <GameScreen config={gameConfig} onEndGame={handleEndGame} />;
@@ -66,11 +71,14 @@ const SpellingBeeGame = () => {
     if (gameState === "leaderboard") {
         return <LeaderboardScreen onBack={handleBackToSetup} />;
     }
+    if (gameState === "achievements") {
+        return <AchievementsScreen onBack={handleBackToSetup} />;
+    }
     return null;
 };
 
 // --- Setup Screen Component ---
-const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
+const SetupScreen = ({ onStartGame, onAddCustomWords, onViewAchievements }) => {
     // This component's logic is kept as is.
     // A simplified version is shown here for brevity.
     const [gameMode, setGameMode] = useState("team");
@@ -94,6 +102,9 @@ const SetupScreen = ({ onStartGame, onAddCustomWords }) => {
             <h1 className="text-4xl text-center">Game Setup</h1>
             <button onClick={handleStart} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold mt-8">
                 START GAME
+            </button>
+            <button onClick={onViewAchievements} className="w-full bg-purple-500 hover:bg-purple-600 text-white px-6 py-4 rounded-xl text-2xl font-bold mt-4">
+                Achievements
             </button>
         </div>
     );

--- a/types.ts
+++ b/types.ts
@@ -55,3 +55,35 @@ export interface LeaderboardEntry {
   date: string;
   avatar?: string;
 }
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  threshold: number;
+}
+
+export const defaultAchievements: Achievement[] = [
+  {
+    id: 'ten-words',
+    name: 'Novice Speller',
+    description: 'Get 10 words correct',
+    icon: '🐣',
+    threshold: 10,
+  },
+  {
+    id: 'fifty-words',
+    name: 'Word Wizard',
+    description: 'Get 50 words correct',
+    icon: '🧙',
+    threshold: 50,
+  },
+  {
+    id: 'hundred-words',
+    name: 'Master Speller',
+    description: 'Get 100 words correct',
+    icon: '🏆',
+    threshold: 100,
+  },
+];


### PR DESCRIPTION
## Summary
- define Achievement type and default badge list
- track and display badge unlocks with toast notifications
- add Achievements screen and navigation entry

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'esbuild')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/canvas-confetti)*

------
https://chatgpt.com/codex/tasks/task_e_68b071e41f708332997245ba9ac4a0b8