### PR TITLE
Add configurable music style and volume to setup screen

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -38,6 +38,8 @@ export interface GameConfig {
   skipPenaltyValue: number;
   soundEnabled: boolean;
   effectsEnabled: boolean;
+  musicStyle: string;
+  musicVolume: number;
   difficultyLevel: number;
   progressionSpeed: number;
   /** When true, the game uses the daily challenge word list */


### PR DESCRIPTION
## Summary
- add glob-based scan of available background tracks and expose style/volume controls on setup screen
- persist music preferences in localStorage and forward to game configuration
- extend `GameConfig` with `musicStyle` and `musicVolume` fields

## Testing
- `npm test`
- `npm run build` *(fails: SyntaxError: Unexpected end of input)*

------
https://chatgpt.com/codex/tasks/task_e_68b094484fd883328768bf143647ae58