### PR TITLE
feat: add background music hook

### DIFF
--- a/utils/useMusic.ts
+++ b/utils/useMusic.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+// Default music style
+const DEFAULT_STYLE = 'Funk';
+
+/**
+ * React hook to manage background music for the app.
+ * Loads menu and gameplay tracks for a given style and
+ * exposes controls to play, stop, change style and adjust volume.
+ */
+const useMusic = (initialStyle: string = DEFAULT_STYLE) => {
+  const menuRef = useRef<HTMLAudioElement | null>(null);
+  const gameRef = useRef<HTMLAudioElement | null>(null);
+
+  const [style, setStyle] = useState(initialStyle);
+  const [volume, setVolume] = useState(1);
+
+  const stop = useCallback(() => {
+    if (menuRef.current) {
+      menuRef.current.pause();
+      menuRef.current.currentTime = 0;
+    }
+    if (gameRef.current) {
+      gameRef.current.pause();
+      gameRef.current.currentTime = 0;
+    }
+  }, []);
+
+  const loadTracks = useCallback((trackStyle: string) => {
+    const basePath = "audio/It's a Spelling Bee!";
+    const menuSrc = `${basePath} (${trackStyle}).mp3`;
+    const gameSrc = `${basePath} (${trackStyle} Instrumental).mp3`;
+
+    const menuAudio = new Audio(menuSrc);
+    menuAudio.loop = true;
+    menuAudio.volume = volume;
+    menuAudio.onerror = () => {
+      console.warn(`Menu music file not found: ${menuSrc}`);
+      if (menuRef.current === menuAudio) menuRef.current = null;
+    };
+
+    const gameAudio = new Audio(gameSrc);
+    gameAudio.loop = true;
+    gameAudio.volume = volume;
+    gameAudio.onerror = () => {
+      console.warn(`Gameplay music file not found: ${gameSrc}`);
+      if (gameRef.current === gameAudio) gameRef.current = null;
+    };
+
+    menuRef.current = menuAudio;
+    gameRef.current = gameAudio;
+  }, [volume]);
+
+  useEffect(() => {
+    loadTracks(style);
+    return () => {
+      stop();
+    };
+  }, [loadTracks, style, stop]);
+
+  const playMenu = useCallback(() => {
+    stop();
+    menuRef.current?.play().catch(() => {});
+  }, [stop]);
+
+  const playGame = useCallback(() => {
+    stop();
+    gameRef.current?.play().catch(() => {});
+  }, [stop]);
+
+  const changeStyle = useCallback((newStyle: string) => {
+    setStyle(newStyle);
+  }, []);
+
+  const changeVolume = useCallback((v: number) => {
+    setVolume(v);
+    if (menuRef.current) menuRef.current.volume = v;
+    if (gameRef.current) gameRef.current.volume = v;
+  }, []);
+
+  return {
+    playMenu,
+    playGame,
+    stop,
+    setStyle: changeStyle,
+    setVolume: changeVolume,
+    style,
+    volume,
+  };
+};
+
+export default useMusic;


### PR DESCRIPTION
## Summary
- add `useMusic` hook to manage looping menu and gameplay music
- support switching music styles, start/stop controls, and volume adjustments

## Testing
- `npm test`
- `npm run build` *(fails: SyntaxError: Unexpected end of input in build.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b0944a0f808332be6fa5a08c7e1d09