### PR TITLE
Add configurable background music support

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -48,6 +48,8 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [progressionSpeed, setProgressionSpeed] = useState(1);
   const [theme, setTheme] = useState('light');
   const [dailyStreak, setDailyStreak] = useState(0);
+  const [musicStyle] = useState('Funk');
+  const [musicVolume] = useState(0.5);
   
   const applyTheme = (t: string) => {
     document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
@@ -120,6 +122,8 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         skipPenaltyValue,
         soundEnabled,
         effectsEnabled,
+        musicStyle,
+        musicVolume,
         difficultyLevel: initialDifficulty,
         progressionSpeed,
         dailyChallenge: true,

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -5,6 +5,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import useMusic from './utils/useMusic';
 
 // --- Main App Component ---
 const SpellingBeeGame = () => {
@@ -73,6 +74,12 @@ const SpellingBeeGame = () => {
             document.body.classList.add(`theme-${savedTheme}`);
         }
     }, []);
+
+    // Handle background music on different screens
+    const musicStyle = gameConfig?.musicStyle || 'Funk';
+    const musicVolume = gameConfig?.musicVolume ?? 0.5;
+    const trackVariant = gameState === 'playing' ? 'instrumental' : 'vocal';
+    useMusic(musicStyle, trackVariant, musicVolume, gameConfig?.soundEnabled ?? true);
 
     if (gameState === "setup") {
         return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;

--- a/types.ts
+++ b/types.ts
@@ -38,6 +38,10 @@ export interface GameConfig {
   skipPenaltyValue: number;
   soundEnabled: boolean;
   effectsEnabled: boolean;
+  /** Background music style identifier */
+  musicStyle: string;
+  /** Volume for background music between 0 and 1 */
+  musicVolume: number;
   difficultyLevel: number;
   progressionSpeed: number;
   /** When true, the game uses the daily challenge word list */

--- a/utils/useMusic.ts
+++ b/utils/useMusic.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * React hook for background music playback with seamless style switching.
+ * It preserves the playback position when changing between vocal and
+ * instrumental tracks of the same style.
+ *
+ * @param style   Music style identifier (e.g. "Funk")
+ * @param variant "vocal" or "instrumental" track variant
+ * @param volume  Volume between 0 and 1
+ * @param enabled Whether music should play
+ */
+export default function useMusic(
+  style: string,
+  variant: 'vocal' | 'instrumental',
+  volume: number,
+  enabled: boolean = true
+) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const timeRef = useRef(0);
+
+  // Load and switch tracks when style or variant changes
+  useEffect(() => {
+    // remember current time of previous track
+    if (audioRef.current) {
+      timeRef.current = audioRef.current.currentTime;
+      audioRef.current.pause();
+    }
+
+    const fileName = `It's a Spelling Bee! (${style}${
+      variant === 'instrumental' ? ' Instrumental' : ''
+    }).mp3`;
+    const src = `audio/${encodeURIComponent(fileName)}`;
+    const audio = new Audio(src);
+    audio.loop = true;
+    audio.volume = volume;
+    audio.currentTime = timeRef.current;
+    if (enabled) audio.play();
+    audioRef.current = audio;
+
+    return () => {
+      audio.pause();
+    };
+  }, [style, variant]);
+
+  // Update volume when it changes
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = volume;
+    }
+  }, [volume]);
+
+  // Enable/disable playback
+  useEffect(() => {
+    if (!audioRef.current) return;
+    if (enabled) {
+      audioRef.current.play();
+    } else {
+      audioRef.current.pause();
+    }
+  }, [enabled]);
+}
+


### PR DESCRIPTION
## Summary
- extend `GameConfig` with `musicStyle` and `musicVolume`
- play vocal or instrumental background music based on game state
- add `useMusic` hook for seamless music switching

## Testing
- `npm test`
- `npm run build` *(fails: SyntaxError in build.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b0944c06088332a6c3cee62534b33f