### PR TITLE
chore: remove dist app from service worker cache

### DIFF
--- a/dist/service-worker.js
+++ b/dist/service-worker.js
@@ -1,10 +1,9 @@
-const CACHE_NAME = 'spelling-bee-cache-v2';
+const CACHE_NAME = 'spelling-bee-cache-v3';
 const ASSETS = [
   './',
   './index.html',
   './style.css',
-  './dist/app.js',
-  './app.js',
+  './app.js', // Cache bundled application script
   './words.json',
   './wordlists/example.json',
   './wordlists/example.csv',

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,11 @@
-const CACHE_NAME = 'spelling-bee-cache-v2';
+const CACHE_NAME = 'spelling-bee-cache-v3';
 const ASSETS = [
   './',
   './index.html',
   './style.css',
   './manifest.webmanifest',
   './icons/icon.svg',
-  './dist/app.js',
-  './app.js',
+  './app.js', // Cache bundled application script
   './words.json',
   './wordlists/example.json',
   './wordlists/example.csv',


### PR DESCRIPTION
## Summary
- remove `./dist/app.js` from service worker cache list
- bump cache name to `spelling-bee-cache-v3` and note `app.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0997682988332a189b744283e6d4c