### PR TITLE
Copy audio assets during build

### DIFF
--- a/build.js
+++ b/build.js
@@ -26,6 +26,7 @@ fs.cpSync('icons', path.join(distDir, 'icons'), { recursive: true });
 if (fs.existsSync('img')) {
     fs.cpSync('img', path.join(distDir, 'img'), { recursive: true });
 }
+fs.cpSync('audio', path.join(distDir, 'audio'), { recursive: true });
 
 // Copy wordlists directory
 const copyDir = (src, dest) => {


### PR DESCRIPTION
## Summary
- Ensure audio directory is copied into `dist` during build so audio assets are available in production

## Testing
- `npm install` *(fails: 403 Forbidden fetching canvas-confetti)*
- `npm run build` *(fails: Cannot find module 'esbuild')*


------
https://chatgpt.com/codex/tasks/task_e_68b099737a988332a9babe06b075a55d