### PR TITLE
Handle fetch errors for leaderboard and setup

### DIFF
--- a/LeaderboardScreen.tsx
+++ b/LeaderboardScreen.tsx
@@ -8,6 +8,7 @@ interface LeaderboardScreenProps {
 
 const LeaderboardScreen: React.FC<LeaderboardScreenProps> = ({ onBack }) => {
   const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     const storedData = localStorage.getItem('leaderboard');
@@ -18,12 +19,19 @@ const LeaderboardScreen: React.FC<LeaderboardScreenProps> = ({ onBack }) => {
     } else {
       // Fallback to a default leaderboard if nothing is in storage
       fetch('leaderboard.json')
-        .then(res => res.json())
+        .then(res => {
+          if (!res.ok) throw new Error('Network response was not ok');
+          return res.json();
+        })
         .then((data: LeaderboardEntry[]) => {
           const sorted = data.sort((a, b) => b.score - a.score).slice(0, 10);
           setEntries(sorted);
+          setError('');
         })
-        .catch(err => console.error("Could not load default leaderboard", err));
+        .catch(err => {
+          console.error('Could not load default leaderboard', err);
+          setError('Failed to load leaderboard.');
+        });
     }
   }, []);
 
@@ -39,7 +47,9 @@ const LeaderboardScreen: React.FC<LeaderboardScreenProps> = ({ onBack }) => {
     <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white text-center flex flex-col items-center justify-center">
       <h1 className="text-6xl font-bold mb-8 text-yellow-300">🏅 Leaderboard</h1>
       <div className="bg-white/10 p-8 rounded-lg w-full max-w-md scorecard">
-        {entries.length === 0 ? (
+        {error ? (
+          <div className="text-xl text-red-300">{error}</div>
+        ) : entries.length === 0 ? (
           <div className="text-xl">No scores yet.</div>
         ) : (
           <ol className="text-xl space-y-2">

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -181,8 +181,18 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   useEffect(() => {
     if (selectedBundledList) {
       fetch(`wordlists/${selectedBundledList}`)
-        .then(res => res.text())
-        .then(text => setCustomWordListText(text));
+        .then(res => {
+          if (!res.ok) throw new Error('Network response was not ok');
+          return res.text();
+        })
+        .then(text => {
+          setCustomWordListText(text);
+          setError('');
+        })
+        .catch(err => {
+          console.error('Failed to load bundled word list', err);
+          setError('Failed to load bundled word list.');
+        });
     }
   }, [selectedBundledList]);
 
@@ -207,7 +217,8 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         const response = await fetch(`wordlists/${randomList.file}`);
         const text = await response.text();
         challengeWords = JSON.parse(text);
-      } catch {
+      } catch (err) {
+        console.error('Failed to load session challenge words', err);
         setError('Failed to load session challenge words.');
         return;
       }


### PR DESCRIPTION
## Summary
- handle default leaderboard fetch failures with error state and message
- surface bundled word list and session challenge fetch errors in setup screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b25e0ab5788332bba3a3d03189abb9