### PR TITLE
Refactor music hook for screen-specific playback

### DIFF
--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -78,8 +78,9 @@ const SpellingBeeGame = () => {
     // Handle background music on different screens
     const musicStyle = gameConfig?.musicStyle || 'Funk';
     const musicVolume = gameConfig?.musicVolume ?? 0.5;
-    const trackVariant = gameState === 'playing' ? 'instrumental' : 'vocal';
-    useMusic(musicStyle, trackVariant, musicVolume, gameConfig?.soundEnabled ?? true);
+    const screen = gameState === 'playing' ? 'game' : 'menu';
+    const trackVariant = screen === 'game' ? 'instrumental' : 'vocal';
+    useMusic(musicStyle, trackVariant, musicVolume, gameConfig?.soundEnabled ?? true, screen);
 
     if (gameState === "setup") {
         return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;


### PR DESCRIPTION
## Summary
- Load both vocal and instrumental tracks once and select based on active screen
- Expose `screen` parameter in `useMusic` and update call sites

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b262a5f5308332853ae98163ee3bae