### PR TITLE
feat: highlight active participant

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -16,6 +16,7 @@ import useWordSelection, { difficultyOrder } from './utils/useWordSelection';
 import OnScreenKeyboard from './components/OnScreenKeyboard';
 import HintPanel from './components/HintPanel';
 import AvatarSelector from './components/AvatarSelector';
+import ScoreCard from './components/ScoreCard';
 import { audioManager } from './utils/audio';
 
 interface GameScreenProps {
@@ -385,11 +386,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       <div className="absolute top-8 left-8 flex gap-8 items-center">
         <img src="img/bee.svg" alt="Bee icon" className="w-12 h-12" />
         {participants.map((p, index) => (
-          <div key={index} className="text-center scorecard">
-            <div className="text-2xl font-bold">{p.name}</div>
-            <div className="text-4xl font-bold text-yellow-300">{'❤️'.repeat(p.lives)}</div>
-            <div className="text-xl font-bold text-green-400">{p.points} pts</div>
-          </div>
+          <ScoreCard key={index} participant={p} isActive={index === currentParticipantIndex} />
         ))}
       </div>
       

--- a/components/ScoreCard.tsx
+++ b/components/ScoreCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Participant } from '../types';
+
+interface ScoreCardProps {
+  participant: Participant;
+  isActive: boolean;
+}
+
+const ScoreCard: React.FC<ScoreCardProps> = ({ participant, isActive }) => {
+  return (
+    <div
+      className={`text-center scorecard transition-transform ${
+        isActive ? 'border-2 border-yellow-300 rounded-lg shadow-lg scale-105' : ''
+      }`}
+    >
+      <div className="text-2xl font-bold">{participant.name}</div>
+      <div className="text-4xl font-bold text-yellow-300">{'❤️'.repeat(participant.lives)}</div>
+      <div className="text-xl font-bold text-green-400">{participant.points} pts</div>
+    </div>
+  );
+};
+
+export default ScoreCard;
+


### PR DESCRIPTION
## Summary
- Extract participant display into reusable `ScoreCard` component
- Highlight active player in game screen using distinctive border and scale

## Testing
- `npx tsc -p tsconfig.json --noEmit` (fails: JSX element implicitly has type 'any')
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26d156d008332b2ec822194656570