### PR TITLE
Disable used keyboard letters and show press feedback

### DIFF
--- a/components/OnScreenKeyboard.tsx
+++ b/components/OnScreenKeyboard.tsx
@@ -1,39 +1,55 @@
-import React from 'react';
-import useSound from '../utils/useSound';
-import letterSoundFile from '../audio/letter-correct.mp3';
+import React from "react";
+import useSound from "../utils/useSound";
+import letterSoundFile from "../audio/letter-correct.mp3";
 
 interface OnScreenKeyboardProps {
   onLetter: (letter: string) => void;
   onBackspace: () => void;
   onSubmit: () => void;
   soundEnabled: boolean;
+  usedLetters: Set<string>;
 }
 
-const letters = Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i));
+const letters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode(65 + i),
+);
 
-const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({ onLetter, onBackspace, onSubmit, soundEnabled }) => {
+const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({
+  onLetter,
+  onBackspace,
+  onSubmit,
+  soundEnabled,
+  usedLetters,
+}) => {
   const playKey = useSound(letterSoundFile, soundEnabled);
 
   return (
     <div className="flex flex-wrap justify-center gap-2 mt-4">
-      {letters.map(letter => (
-        <button
-          key={letter}
-          onClick={() => {
-            playKey();
-            onLetter(letter.toLowerCase());
-          }}
-          className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
-        >
-          {letter}
-        </button>
-      ))}
+      {letters.map((letter) => {
+        const lower = letter.toLowerCase();
+        const isUsed = usedLetters.has(lower);
+        return (
+          <button
+            key={letter}
+            onClick={() => {
+              playKey();
+              onLetter(lower);
+            }}
+            disabled={isUsed}
+            className={`px-4 py-2 rounded-lg font-bold transition-transform active:scale-95 ${
+              isUsed ? "bg-gray-300 text-gray-500" : "bg-yellow-300 text-black"
+            }`}
+          >
+            {letter}
+          </button>
+        );
+      })}
       <button
         onClick={() => {
           playKey();
           onBackspace();
         }}
-        className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+        className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold transition-transform active:scale-95"
         aria-label="Backspace"
       >
         <span aria-hidden="true">⌫</span>
@@ -43,7 +59,7 @@ const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({ onLetter, onBackspa
           playKey();
           onSubmit();
         }}
-        className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg font-bold"
+        className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg font-bold transition-transform active:scale-95"
         aria-label="Submit"
       >
         <span aria-hidden="true">✅</span>


### PR DESCRIPTION
## Summary
- track typed letters so on-screen keyboard disables used keys
- gray out disabled letters and add press animation for feedback

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve "../constants/achievements"; Could not resolve "../wordlists/words.json"; Could not resolve "../constants/avatars")*


------
https://chatgpt.com/codex/tasks/task_e_68b26d17624c83329d4e7563aa7a12bc