### PR TITLE
Refactor setup screen into modular components

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -3,10 +3,10 @@ import { Word, Participant, GameConfig } from './types';
 import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
 import trophyImg from './img/avatars/trophy.svg';
-
-// Gather available music styles.
-// This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
-const musicStyles = ['Funk', 'Country', 'Deep Bass', 'Rock', 'Jazz', 'Classical'];
+import TeamForm from './components/TeamForm';
+import StudentRoster from './components/StudentRoster';
+import GameOptions, { OptionsState } from './components/GameOptions';
+import useRoster from './hooks/useRoster';
 
 interface SetupScreenProps {
   onStartGame: (config: GameConfig) => void;
@@ -23,7 +23,22 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     { name: 'Team Beta', lives: 5, difficultyLevel: 0, points: 0, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0, avatar: getRandomAvatar() }
   ];
 
-  const [teams, setTeams] = useState<Participant[]>(getDefaultTeams());
+  const {
+    participants: teams,
+    addParticipant: addTeamParticipant,
+    removeParticipant: removeTeam,
+    updateName: updateTeamName,
+    clear: clearTeams,
+  } = useRoster('teams', getDefaultTeams());
+
+  const {
+    participants: students,
+    addParticipant: addStudentParticipant,
+    removeParticipant: removeStudent,
+    updateName: updateStudentName,
+    clear: clearStudents,
+  } = useRoster('students', []);
+
   const [gameMode, setGameMode] = useState<'team' | 'individual'>('team');
   const [timerDuration, setTimerDuration] = useState(30);
   const [customWordListText, setCustomWordListText] = useState('');
@@ -37,109 +52,38 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     { label: 'Example TSV', file: 'example.tsv' }
   ];
   const [selectedBundledList, setSelectedBundledList] = useState('');
-  const [students, setStudents] = useState<Participant[]>([]);
-  const [studentName, setStudentName] = useState('');
-  const [bulkStudentText, setBulkStudentText] = useState('');
-  const [bulkStudentError, setBulkStudentError] = useState('');
-  const [skipPenaltyType, setSkipPenaltyType] = useState<'lives' | 'points'>('lives');
-  const [skipPenaltyValue, setSkipPenaltyValue] = useState(1);
-  const [soundEnabled, setSoundEnabled] = useState<boolean>(() => localStorage.getItem('soundEnabled') !== 'false');
-  const [effectsEnabled, setEffectsEnabled] = useState(true);
-  const [musicStyle, setMusicStyle] = useState<string>(() => localStorage.getItem('musicStyle') ?? 'Funk');
-  const [musicVolume, setMusicVolume] = useState<number>(() => parseFloat(localStorage.getItem('musicVolume') ?? '1'));
-  const [initialDifficulty, setInitialDifficulty] = useState(0);
-  const [progressionSpeed, setProgressionSpeed] = useState(1);
-  const [theme, setTheme] = useState('light');
-  const [teacherMode, setTeacherMode] = useState<boolean>(() => localStorage.getItem('teacherMode') === 'true');
 
-  const applyTheme = (t: string) => {
-    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
-    document.body.classList.add(`theme-${t}`);
-  };
-
-  useEffect(() => {
-    if (teacherMode) {
-      document.body.classList.add('teacher-mode');
-    } else {
-      document.body.classList.remove('teacher-mode');
-    }
-    localStorage.setItem('teacherMode', String(teacherMode));
-  }, [teacherMode]);
-  
-  useEffect(() => {
-    const savedTeams = localStorage.getItem('teams');
-    if (savedTeams) try { setTeams(JSON.parse(savedTeams).map((t: Participant) => ({ ...t, avatar: t.avatar || getRandomAvatar() }))); } catch {}
-    const savedStudents = localStorage.getItem('students');
-    if (savedStudents) try { setStudents(JSON.parse(savedStudents).map((s: Participant) => ({ ...s, avatar: s.avatar || getRandomAvatar() }))); } catch {}
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      setTheme(savedTheme);
-      applyTheme(savedTheme);
-    } else {
-      applyTheme(theme);
-    }
-  }, []);
-
-  useEffect(() => localStorage.setItem('soundEnabled', String(soundEnabled)), [soundEnabled]);
-  useEffect(() => localStorage.setItem('musicStyle', musicStyle), [musicStyle]);
-  useEffect(() => localStorage.setItem('musicVolume', String(musicVolume)), [musicVolume]);
-
-  const updateTeams = (newTeams: Participant[]) => {
-    setTeams(newTeams);
-    localStorage.setItem('teams', JSON.stringify(newTeams));
-  };
-
-  const updateStudents = (newStudents: Participant[]) => {
-    setStudents(newStudents);
-    localStorage.setItem('students', JSON.stringify(newStudents));
-  };
-
-  const clearRoster = () => {
-    localStorage.removeItem('teams');
-    localStorage.removeItem('students');
-    setTeams(getDefaultTeams());
-    setStudents([]);
-  };
-
-  const createParticipant = (name: string, difficulty: number): Participant => ({
-    name: name.trim(), lives: 5, points: 0, difficultyLevel: difficulty, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0, avatar: getRandomAvatar()
+  const [options, setOptions] = useState<OptionsState>({
+    skipPenaltyType: 'lives',
+    skipPenaltyValue: 1,
+    initialDifficulty: 0,
+    progressionSpeed: 1,
+    soundEnabled: localStorage.getItem('soundEnabled') !== 'false',
+    effectsEnabled: true,
+    theme: localStorage.getItem('theme') ?? 'light',
+    teacherMode: localStorage.getItem('teacherMode') === 'true',
+    musicStyle: localStorage.getItem('musicStyle') ?? 'Funk',
+    musicVolume: parseFloat(localStorage.getItem('musicVolume') ?? '1'),
   });
 
-  const addTeam = () => updateTeams([...teams, createParticipant('', 0)]);
-  const removeTeam = (index: number) => updateTeams(teams.filter((_, i) => i !== index));
-  const updateTeamName = (index: number, name: string) => {
-    const newTeams = teams.map((team, i) => (i === index ? { ...team, name } : team));
-    updateTeams(newTeams);
-  };
+  const createParticipant = (name: string, difficulty: number): Participant => ({
+    name: name.trim(),
+    lives: 5,
+    points: 0,
+    difficultyLevel: difficulty,
+    streak: 0,
+    attempted: 0,
+    correct: 0,
+    wordsAttempted: 0,
+    wordsCorrect: 0,
+    avatar: getRandomAvatar(),
+  });
 
-  const addStudent = () => {
-    if (studentName.trim()) {
-      updateStudents([...students, createParticipant(studentName, initialDifficulty)]);
-      setStudentName('');
-    }
-  };
+  const addTeam = () => addTeamParticipant(createParticipant('', 0));
 
-  const removeStudent = (index: number) => updateStudents(students.filter((_, i) => i !== index));
-  const updateStudentName = (index: number, name: string) => {
-    const newStudents = students.map((student, i) => (i === index ? { ...student, name } : student));
-    updateStudents(newStudents);
-  };
-
-  const parseStudentNames = (text: string) =>
-    text.split(/\r?\n/).flatMap(line => line.split(',')).map(name => name.trim()).filter(name => name !== '');
-
-  const addBulkStudents = () => {
-    const names = parseStudentNames(bulkStudentText);
-    const existing = new Set(students.map(s => s.name));
-    const uniqueNames = Array.from(new Set(names)).filter(name => !existing.has(name));
-    if (uniqueNames.length === 0) {
-      setBulkStudentError('No new unique names detected.');
-      return;
-    }
-    const newStudents = uniqueNames.map(name => createParticipant(name, initialDifficulty));
-    updateStudents([...students, ...newStudents]);
-    setBulkStudentText('');
-    setBulkStudentError('');
+  const clearRoster = () => {
+    clearTeams();
+    clearStudents();
   };
   
   const parseWordList = (content: string) => {
@@ -231,16 +175,16 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             setError('Please add at least two teams with names.');
             return;
         }
-        finalParticipants = trimmedTeams.map(t => ({...t, difficultyLevel: initialDifficulty}));
+        finalParticipants = trimmedTeams.map(t => ({...t, difficultyLevel: options.initialDifficulty}));
     } else {
         const trimmedStudents = students.filter(student => student.name.trim() !== "");
         if (trimmedStudents.length < 1 && isSessionChallenge) {
-             finalParticipants = [createParticipant('Player 1', initialDifficulty)];
+             finalParticipants = [createParticipant('Player 1', options.initialDifficulty)];
         } else if (trimmedStudents.length < 2 && !isSessionChallenge) {
             setError('Please add at least two students for a custom game.');
             return;
         } else {
-             finalParticipants = trimmedStudents.map(s => ({...s, difficultyLevel: initialDifficulty}));
+             finalParticipants = trimmedStudents.map(s => ({...s, difficultyLevel: options.initialDifficulty}));
         }
     }
 
@@ -256,7 +200,16 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     
     const config: GameConfig = {
       participants: finalParticipants,
-      gameMode, timerDuration, skipPenaltyType, skipPenaltyValue, soundEnabled, effectsEnabled, difficultyLevel: initialDifficulty, progressionSpeed, musicStyle, musicVolume,
+      gameMode,
+      timerDuration,
+      skipPenaltyType: options.skipPenaltyType,
+      skipPenaltyValue: options.skipPenaltyValue,
+      soundEnabled: options.soundEnabled,
+      effectsEnabled: options.effectsEnabled,
+      difficultyLevel: options.initialDifficulty,
+      progressionSpeed: options.progressionSpeed,
+      musicStyle: options.musicStyle,
+      musicVolume: options.musicVolume,
     };
     onStartGame(config);
   };
@@ -283,98 +236,28 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         <div className="bg-white/10 p-6 rounded-lg mb-8">
           <h2 className="text-2xl font-bold mb-4">{gameMode === 'team' ? 'Teams 👥' : 'Students 🧑‍🎓'}</h2>
           {gameMode === 'team' ? (
-            <>
-              {teams.map((team, index) => (
-                <div key={index} className="flex items-center gap-2 mb-2">
-                  <img src={team.avatar || avatars[0]} alt="avatar" className="w-8 h-8 rounded-full" />
-                  <input type="text" value={team.name} onChange={e => updateTeamName(index, e.target.value)} placeholder={`Team ${index + 1} Name`} className="flex-grow p-2 rounded-md bg-white/20 text-white" />
-                  {teams.length > 1 && (<button onClick={() => removeTeam(index)} className="px-2 py-1 bg-red-500 hover:bg-red-600 rounded">Remove</button>)}
-                </div>
-              ))}
-              <button onClick={addTeam} className="mt-2 bg-green-500 hover:bg-green-600 px-4 py-2 rounded">Add Team</button>
-            </>
+            <TeamForm
+              teams={teams}
+              avatars={avatars}
+              addTeam={addTeam}
+              removeTeam={removeTeam}
+              updateTeamName={updateTeamName}
+            />
           ) : (
-            <>
-              <div className="flex gap-4 mb-4">
-                <input type="text" value={studentName} onChange={e => setStudentName(e.target.value)} className="flex-grow p-2 rounded-md bg-white/20 text-white" placeholder="Student name" />
-                <button onClick={addStudent} className="bg-green-500 hover:bg-green-600 px-4 py-2 rounded-lg font-bold">Add</button>
-              </div>
-              <div className="mb-4">
-                <textarea value={bulkStudentText} onChange={e => setBulkStudentText(e.target.value)} className="w-full p-2 rounded-md bg-white/20 text-white mb-2" placeholder="Paste names, one per line or separated by commas" rows={4}></textarea>
-                <button onClick={addBulkStudents} className="bg-green-500 hover:bg-green-600 px-4 py-2 rounded-lg font-bold">Add Names</button>
-                {bulkStudentError && <p className="text-red-300 mt-2">{bulkStudentError}</p>}
-              </div>
-              {students.map((student, index) => (
-                <div key={index} className="flex items-center gap-2 mb-2">
-                  <img src={student.avatar || avatars[0]} alt="avatar" className="w-8 h-8 rounded-full" />
-                  <input type="text" value={student.name} onChange={e => updateStudentName(index, e.target.value)} placeholder="Student name" className="flex-grow p-2 rounded-md bg-white/20 text-white" />
-                  {students.length > 0 && (<button onClick={() => removeStudent(index)} className="px-2 py-1 bg-red-500 hover:bg-red-600 rounded">Remove</button>)}
-                </div>
-              ))}
-            </>
+            <StudentRoster
+              students={students}
+              avatars={avatars}
+              addParticipant={addStudentParticipant}
+              removeStudent={removeStudent}
+              updateStudentName={updateStudentName}
+              createParticipant={createParticipant}
+              initialDifficulty={options.initialDifficulty}
+            />
           )}
           <button onClick={clearRoster} className="mt-4 bg-red-500 hover:bg-red-600 px-4 py-2 rounded">Clear Saved Roster</button>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4">Skip Penalty ⏭️</h2>
-                <div className="flex gap-4">
-                    <select value={skipPenaltyType} onChange={e => setSkipPenaltyType(e.target.value as 'lives' | 'points')} className="p-2 rounded-md bg-white/20 text-white">
-                        <option value="lives">Lives</option>
-                        <option value="points">Points</option>
-                    </select>
-                    <input type="number" min={0} value={skipPenaltyValue} onChange={e => setSkipPenaltyValue(Number(e.target.value))} className="p-2 rounded-md bg-white/20 text-white w-24" />
-                </div>
-            </div>
-            <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4">Difficulty Settings 🎚️</h2>
-                <div className="flex gap-4">
-                    <div>
-                        <label className="block mb-2">Initial Difficulty</label>
-                        <select value={initialDifficulty} onChange={e => setInitialDifficulty(Number(e.target.value))} className="p-2 rounded-md bg-white/20 text-white">
-                            <option value={0}>Easy</option>
-                            <option value={1}>Medium</option>
-                            <option value={2}>Tricky</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label className="block mb-2">Progression Speed</label>
-                        <input type="number" min={1} value={progressionSpeed} onChange={e => setProgressionSpeed(Number(e.target.value))} className="p-2 rounded-md bg-white/20 text-white w-24" />
-                    </div>
-                </div>
-            </div>
-            <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4">Audio & Effects 🔊✨</h2>
-                <label className="flex items-center space-x-3 mb-2"><input type="checkbox" checked={soundEnabled} onChange={e => setSoundEnabled(e.target.checked)} /><span>Enable Sound</span></label>
-                <label className="flex items-center space-x-3"><input type="checkbox" checked={effectsEnabled} onChange={e => setEffectsEnabled(e.target.checked)} /><span>Enable Visual Effects</span></label>
-            </div>
-            <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>
-                <select value={theme} onChange={e => { const t = e.target.value; setTheme(t); localStorage.setItem('theme', t); applyTheme(t); }} className="p-2 rounded-md bg-white/20 text-white">
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="honeycomb">Honeycomb</option>
-                </select>
-            </div>
-            <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4">Teacher Mode 👩‍🏫</h2>
-                <label className="flex items-center gap-2 text-white"><input type="checkbox" checked={teacherMode} onChange={e => setTeacherMode(e.target.checked)} /><span>Enable larger fonts and spacing</span></label>
-            </div>
-             <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4">Music 🎵</h2>
-                <div className="mb-4">
-                    <label className="block mb-2">Style</label>
-                    <select value={musicStyle} onChange={e => setMusicStyle(e.target.value)} className="p-2 rounded-md bg-white/20 text-white">
-                        {musicStyles.map(style => (<option key={style} value={style}>{style}</option>))}
-                    </select>
-                </div>
-                <div>
-                    <label className="block mb-2">Volume: {Math.round(musicVolume * 100)}%</label>
-                    <input type="range" min={0} max={1} step={0.01} value={musicVolume} onChange={e => setMusicVolume(parseFloat(e.target.value))} className="w-full" />
-                </div>
-            </div>
-        </div>
+        <GameOptions options={options} setOptions={setOptions} />
         
         <div className="bg-white/10 p-6 rounded-lg mb-8 mt-8">
             <h2 className="text-2xl font-bold mb-4">Add Custom Word List 📝</h2>

--- a/components/GameOptions.tsx
+++ b/components/GameOptions.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect } from 'react';
+
+export interface OptionsState {
+  skipPenaltyType: 'lives' | 'points';
+  skipPenaltyValue: number;
+  initialDifficulty: number;
+  progressionSpeed: number;
+  soundEnabled: boolean;
+  effectsEnabled: boolean;
+  theme: string;
+  teacherMode: boolean;
+  musicStyle: string;
+  musicVolume: number;
+}
+
+interface GameOptionsProps {
+  options: OptionsState;
+  setOptions: React.Dispatch<React.SetStateAction<OptionsState>>;
+}
+
+const GameOptions: React.FC<GameOptionsProps> = ({ options, setOptions }) => {
+  const applyTheme = (t: string) => {
+    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
+    document.body.classList.add(`theme-${t}`);
+  };
+
+  useEffect(() => {
+    localStorage.setItem('soundEnabled', String(options.soundEnabled));
+  }, [options.soundEnabled]);
+
+  useEffect(() => {
+    localStorage.setItem('musicStyle', options.musicStyle);
+  }, [options.musicStyle]);
+
+  useEffect(() => {
+    localStorage.setItem('musicVolume', String(options.musicVolume));
+  }, [options.musicVolume]);
+
+  useEffect(() => {
+    if (options.teacherMode) {
+      document.body.classList.add('teacher-mode');
+    } else {
+      document.body.classList.remove('teacher-mode');
+    }
+    localStorage.setItem('teacherMode', String(options.teacherMode));
+  }, [options.teacherMode]);
+
+  useEffect(() => {
+    applyTheme(options.theme);
+    localStorage.setItem('theme', options.theme);
+  }, [options.theme]);
+
+  return (
+    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div className="bg-white/10 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">Skip Penalty ⏭️</h2>
+        <div className="flex gap-4">
+          <select
+            value={options.skipPenaltyType}
+            onChange={e =>
+              setOptions(o => ({ ...o, skipPenaltyType: e.target.value as 'lives' | 'points' }))
+            }
+            className="p-2 rounded-md bg-white/20 text-white"
+          >
+            <option value="lives">Lives</option>
+            <option value="points">Points</option>
+          </select>
+          <input
+            type="number"
+            min={0}
+            value={options.skipPenaltyValue}
+            onChange={e =>
+              setOptions(o => ({ ...o, skipPenaltyValue: Number(e.target.value) }))
+            }
+            className="p-2 rounded-md bg-white/20 text-white w-24"
+          />
+        </div>
+      </div>
+
+      <div className="bg-white/10 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">Difficulty Settings 🎚️</h2>
+        <div className="flex gap-4">
+          <div>
+            <label className="block mb-2">Initial Difficulty</label>
+            <select
+              value={options.initialDifficulty}
+              onChange={e =>
+                setOptions(o => ({ ...o, initialDifficulty: Number(e.target.value) }))
+              }
+              className="p-2 rounded-md bg-white/20 text-white"
+            >
+              <option value={0}>Easy</option>
+              <option value={1}>Medium</option>
+              <option value={2}>Tricky</option>
+            </select>
+          </div>
+          <div>
+            <label className="block mb-2">Progression Speed</label>
+            <input
+              type="number"
+              min={1}
+              value={options.progressionSpeed}
+              onChange={e =>
+                setOptions(o => ({ ...o, progressionSpeed: Number(e.target.value) }))
+              }
+              className="p-2 rounded-md bg-white/20 text-white w-24"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white/10 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">Audio & Effects 🔊✨</h2>
+        <label className="flex items-center space-x-3 mb-2">
+          <input
+            type="checkbox"
+            checked={options.soundEnabled}
+            onChange={e => setOptions(o => ({ ...o, soundEnabled: e.target.checked }))}
+          />
+          <span>Enable Sound</span>
+        </label>
+        <label className="flex items-center space-x-3">
+          <input
+            type="checkbox"
+            checked={options.effectsEnabled}
+            onChange={e => setOptions(o => ({ ...o, effectsEnabled: e.target.checked }))}
+          />
+          <span>Enable Visual Effects</span>
+        </label>
+      </div>
+
+      <div className="bg-white/10 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>
+        <select
+          value={options.theme}
+          onChange={e => setOptions(o => ({ ...o, theme: e.target.value }))}
+          className="p-2 rounded-md bg-white/20 text-white"
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="honeycomb">Honeycomb</option>
+        </select>
+      </div>
+
+      <div className="bg-white/10 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">Teacher Mode 👩‍🏫</h2>
+        <label className="flex items-center gap-2 text-white">
+          <input
+            type="checkbox"
+            checked={options.teacherMode}
+            onChange={e => setOptions(o => ({ ...o, teacherMode: e.target.checked }))}
+          />
+          <span>Enable larger fonts and spacing</span>
+        </label>
+      </div>
+
+      <div className="bg-white/10 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">Music 🎵</h2>
+        <div className="mb-4">
+          <label className="block mb-2">Style</label>
+          <select
+            value={options.musicStyle}
+            onChange={e => setOptions(o => ({ ...o, musicStyle: e.target.value }))}
+            className="p-2 rounded-md bg-white/20 text-white"
+          >
+            {['Funk', 'Country', 'Deep Bass', 'Rock', 'Jazz', 'Classical'].map(style => (
+              <option key={style} value={style}>
+                {style}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-2">Volume: {Math.round(options.musicVolume * 100)}%</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={options.musicVolume}
+            onChange={e =>
+              setOptions(o => ({ ...o, musicVolume: parseFloat(e.target.value) }))
+            }
+            className="w-full"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GameOptions;

--- a/components/StudentRoster.tsx
+++ b/components/StudentRoster.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { Participant } from '../types';
+
+interface StudentRosterProps {
+  students: Participant[];
+  avatars: string[];
+  addParticipant: (p: Participant) => void;
+  removeStudent: (index: number) => void;
+  updateStudentName: (index: number, name: string) => void;
+  createParticipant: (name: string, difficulty: number) => Participant;
+  initialDifficulty: number;
+}
+
+const StudentRoster: React.FC<StudentRosterProps> = ({
+  students,
+  avatars,
+  addParticipant,
+  removeStudent,
+  updateStudentName,
+  createParticipant,
+  initialDifficulty,
+}) => {
+  const [studentName, setStudentName] = useState('');
+  const [bulkStudentText, setBulkStudentText] = useState('');
+  const [bulkStudentError, setBulkStudentError] = useState('');
+
+  const addStudent = () => {
+    if (studentName.trim()) {
+      addParticipant(createParticipant(studentName, initialDifficulty));
+      setStudentName('');
+    }
+  };
+
+  const parseStudentNames = (text: string) =>
+    text
+      .split(/\r?\n/)
+      .flatMap(line => line.split(','))
+      .map(name => name.trim())
+      .filter(name => name !== '');
+
+  const addBulkStudents = () => {
+    const names = parseStudentNames(bulkStudentText);
+    const existing = new Set(students.map(s => s.name));
+    const uniqueNames = Array.from(new Set(names)).filter(name => !existing.has(name));
+    if (uniqueNames.length === 0) {
+      setBulkStudentError('No new unique names detected.');
+      return;
+    }
+    uniqueNames.forEach(name => addParticipant(createParticipant(name, initialDifficulty)));
+    setBulkStudentText('');
+    setBulkStudentError('');
+  };
+
+  return (
+    <>
+      <div className="flex gap-4 mb-4">
+        <input
+          type="text"
+          value={studentName}
+          onChange={e => setStudentName(e.target.value)}
+          className="flex-grow p-2 rounded-md bg-white/20 text-white"
+          placeholder="Student name"
+        />
+        <button
+          onClick={addStudent}
+          className="bg-green-500 hover:bg-green-600 px-4 py-2 rounded-lg font-bold"
+        >
+          Add
+        </button>
+      </div>
+      <div className="mb-4">
+        <textarea
+          value={bulkStudentText}
+          onChange={e => setBulkStudentText(e.target.value)}
+          className="w-full p-2 rounded-md bg-white/20 text-white mb-2"
+          placeholder="Paste names, one per line or separated by commas"
+          rows={4}
+        ></textarea>
+        <button
+          onClick={addBulkStudents}
+          className="bg-green-500 hover:bg-green-600 px-4 py-2 rounded-lg font-bold"
+        >
+          Add Names
+        </button>
+        {bulkStudentError && <p className="text-red-300 mt-2">{bulkStudentError}</p>}
+      </div>
+      {students.map((student, index) => (
+        <div key={index} className="flex items-center gap-2 mb-2">
+          <img src={student.avatar || avatars[0]} alt="avatar" className="w-8 h-8 rounded-full" />
+          <input
+            type="text"
+            value={student.name}
+            onChange={e => updateStudentName(index, e.target.value)}
+            placeholder="Student name"
+            className="flex-grow p-2 rounded-md bg-white/20 text-white"
+          />
+          {students.length > 0 && (
+            <button
+              onClick={() => removeStudent(index)}
+              className="px-2 py-1 bg-red-500 hover:bg-red-600 rounded"
+            >
+              Remove
+            </button>
+          )}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default StudentRoster;

--- a/components/TeamForm.tsx
+++ b/components/TeamForm.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Participant } from '../types';
+
+interface TeamFormProps {
+  teams: Participant[];
+  avatars: string[];
+  addTeam: () => void;
+  removeTeam: (index: number) => void;
+  updateTeamName: (index: number, name: string) => void;
+}
+
+const TeamForm: React.FC<TeamFormProps> = ({
+  teams,
+  avatars,
+  addTeam,
+  removeTeam,
+  updateTeamName,
+}) => (
+  <>
+    {teams.map((team, index) => (
+      <div key={index} className="flex items-center gap-2 mb-2">
+        <img src={team.avatar || avatars[0]} alt="avatar" className="w-8 h-8 rounded-full" />
+        <input
+          type="text"
+          value={team.name}
+          onChange={e => updateTeamName(index, e.target.value)}
+          placeholder={`Team ${index + 1} Name`}
+          className="flex-grow p-2 rounded-md bg-white/20 text-white"
+        />
+        {teams.length > 1 && (
+          <button
+            onClick={() => removeTeam(index)}
+            className="px-2 py-1 bg-red-500 hover:bg-red-600 rounded"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+    ))}
+    <button onClick={addTeam} className="mt-2 bg-green-500 hover:bg-green-600 px-4 py-2 rounded">
+      Add Team
+    </button>
+  </>
+);
+
+export default TeamForm;

--- a/hooks/useRoster.ts
+++ b/hooks/useRoster.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import { Participant } from '../types';
+
+/**
+ * Manage a roster of participants with localStorage persistence.
+ * @param storageKey Key used to persist the roster
+ * @param defaultParticipants Initial participants when none are stored
+ */
+export const useRoster = (
+  storageKey: string,
+  defaultParticipants: Participant[] = []
+) => {
+  const [participants, setParticipants] = useState<Participant[]>(() => {
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      try {
+        return JSON.parse(saved) as Participant[];
+      } catch {
+        return defaultParticipants;
+      }
+    }
+    return defaultParticipants;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(storageKey, JSON.stringify(participants));
+  }, [storageKey, participants]);
+
+  const addParticipant = (participant: Participant) =>
+    setParticipants(prev => [...prev, participant]);
+
+  const removeParticipant = (index: number) =>
+    setParticipants(prev => prev.filter((_, i) => i !== index));
+
+  const updateName = (index: number, name: string) =>
+    setParticipants(prev => prev.map((p, i) => (i === index ? { ...p, name } : p)));
+
+  const clear = () => {
+    localStorage.removeItem(storageKey);
+    setParticipants(defaultParticipants);
+  };
+
+  return { participants, addParticipant, removeParticipant, updateName, clear, setParticipants };
+};
+
+export default useRoster;


### PR DESCRIPTION
## Summary
- add reusable `useRoster` hook with localStorage persistence
- introduce `TeamForm`, `StudentRoster`, and `GameOptions` components
- simplify `SetupScreen` to orchestrate rosters and options via new subcomponents

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve constants/achievements, constants/avatars, wordlists/words.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b26d19c8508332b78eae9c5631608a