### PR TITLE
feat: add configurable TTS voice

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -51,6 +51,8 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [progressionSpeed, setProgressionSpeed] = useState(1);
   const [theme, setTheme] = useState('light');
   const [teacherMode, setTeacherMode] = useState<boolean>(() => localStorage.getItem('teacherMode') === 'true');
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [selectedVoice, setSelectedVoice] = useState<string>(() => localStorage.getItem('selectedVoice') ?? '');
 
   const applyTheme = (t: string) => {
     document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
@@ -83,6 +85,21 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   useEffect(() => localStorage.setItem('soundEnabled', String(soundEnabled)), [soundEnabled]);
   useEffect(() => localStorage.setItem('musicStyle', musicStyle), [musicStyle]);
   useEffect(() => localStorage.setItem('musicVolume', String(musicVolume)), [musicVolume]);
+  useEffect(() => {
+    if (selectedVoice) {
+      localStorage.setItem('selectedVoice', selectedVoice);
+    } else {
+      localStorage.removeItem('selectedVoice');
+    }
+  }, [selectedVoice]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('speechSynthesis' in window)) return;
+    const loadVoices = () => setVoices(window.speechSynthesis.getVoices());
+    loadVoices();
+    window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
+    return () => window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
+  }, []);
 
   const updateTeams = (newTeams: Participant[]) => {
     setTeams(newTeams);
@@ -348,6 +365,17 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 <h2 className="text-2xl font-bold mb-4">Audio & Effects 🔊✨</h2>
                 <label className="flex items-center space-x-3 mb-2"><input type="checkbox" checked={soundEnabled} onChange={e => setSoundEnabled(e.target.checked)} /><span>Enable Sound</span></label>
                 <label className="flex items-center space-x-3"><input type="checkbox" checked={effectsEnabled} onChange={e => setEffectsEnabled(e.target.checked)} /><span>Enable Visual Effects</span></label>
+                {voices.length > 0 && (
+                    <div className="mt-4">
+                        <label className="block mb-2">Voice</label>
+                        <select value={selectedVoice} onChange={e => setSelectedVoice(e.target.value)} className="p-2 rounded-md bg-white/20 text-white">
+                            <option value="">Default</option>
+                            {voices.map(v => (
+                                <option key={v.voiceURI} value={v.voiceURI}>{`${v.name} (${v.lang})`}</option>
+                            ))}
+                        </select>
+                    </div>
+                )}
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>

--- a/utils/tts.ts
+++ b/utils/tts.ts
@@ -1,9 +1,31 @@
-export const speak = (text: string) => {
+export interface SpeakOptions {
+  voice?: SpeechSynthesisVoice;
+  rate?: number;
+  pitch?: number;
+}
+
+export const speak = (text: string, options: SpeakOptions = {}) => {
   if (typeof window === 'undefined' || !('speechSynthesis' in window)) {
     return;
   }
-  
+
   const utterance = new SpeechSynthesisUtterance(text);
+  const { voice, rate, pitch } = options;
+
+  if (voice) {
+    utterance.voice = voice;
+  } else {
+    const savedVoice = localStorage.getItem('selectedVoice');
+    if (savedVoice) {
+      const voices = window.speechSynthesis.getVoices();
+      const matched = voices.find(v => v.voiceURI === savedVoice || v.name === savedVoice);
+      if (matched) utterance.voice = matched;
+    }
+  }
+
+  if (rate) utterance.rate = rate;
+  if (pitch) utterance.pitch = pitch;
+
   window.speechSynthesis.cancel();
   window.speechSynthesis.speak(utterance);
 };


### PR DESCRIPTION
## Summary
- extend text-to-speech helper to support voice, rate, and pitch options with localStorage fallback
- allow players to select preferred speech synthesis voice in setup

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve "../constants/achievements")*

------
https://chatgpt.com/codex/tasks/task_e_68b26d18e02083328bd095b208ea99b7