### PR TITLE
Validate custom word list entries

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -3,6 +3,7 @@ import { Word, Participant, GameConfig } from './types';
 import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
 import trophyImg from './img/avatars/trophy.svg';
+import { parseWordList as parseWordListUtil } from './utils/parseWordList';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -144,26 +145,12 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   
   const parseWordList = (content: string) => {
     try {
-      const parsed = JSON.parse(content) as Word[];
-      if (Array.isArray(parsed)) {
-        setParsedCustomWords(parsed);
-        return;
-      }
-    } catch (e) {}
-
-    const lines = content.trim().split('\n');
-    if (lines.length < 2) return;
-    const delimiter = lines[0].includes(',') ? ',' : '\t';
-    const headers = lines[0].split(delimiter).map(h => h.trim());
-    const words = lines.slice(1).map(line => {
-      const values = line.split(delimiter);
-      const wordObj: any = {};
-      headers.forEach((header, index) => {
-        wordObj[header] = values[index] ? values[index].trim() : '';
-      });
-      return wordObj as Word;
-    });
-    setParsedCustomWords(words);
+      const words = parseWordListUtil(content);
+      setParsedCustomWords(words);
+      setError('');
+    } catch (e: any) {
+      setError(e.message || 'Invalid word list format.');
+    }
   };
   
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:css": "npx @tailwindcss/cli -i ./src/tailwind.css -o ./tailwind.css --minify",
     "build": "npm run build:css && npx esbuild spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --target=es2020 --format=esm --loader:.mp3=file --loader:.svg=file --loader:.png=file --loader:.jpg=file --loader:.jpeg=file && node scripts/copy-assets.js",
     "watch": "npx esbuild spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --watch",
-    "test": "echo 'No tests configured yet'",
+    "test": "node --test",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
   },

--- a/tests/parseWordList.test.js
+++ b/tests/parseWordList.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { test } = require('node:test');
+const { parseWordList } = require('../utils/parseWordList');
+
+test('throws for JSON missing required fields', () => {
+  const badJson = JSON.stringify([{ word: 'apple' }]);
+  assert.throws(() => parseWordList(badJson), /missing required field/i);
+});
+
+test('throws for CSV missing required fields', () => {
+  const csv = 'word,definition\napple,';
+  assert.throws(() => parseWordList(csv), /missing required field/i);
+});
+
+test('throws for TSV missing required fields', () => {
+  const tsv = 'word\tdefinition\napple\t';
+  assert.throws(() => parseWordList(tsv), /missing required field/i);
+});

--- a/utils/parseWordList.d.ts
+++ b/utils/parseWordList.d.ts
@@ -1,0 +1,2 @@
+import { Word } from '../types';
+export function parseWordList(content: string): Word[];

--- a/utils/parseWordList.js
+++ b/utils/parseWordList.js
@@ -1,0 +1,51 @@
+const requiredFields = ['word', 'definition'];
+
+function validateWords(words) {
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i];
+    for (const field of requiredFields) {
+      if (!w[field]) {
+        throw new Error(`Word at index ${i} is missing required field '${field}'`);
+      }
+    }
+  }
+}
+
+function parseWordList(content) {
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      validateWords(parsed);
+      return parsed;
+    }
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // Ignore JSON parse errors
+    } else {
+      throw e;
+    }
+  }
+
+  const lines = content.trim().split('\n');
+  if (lines.length < 2) {
+    throw new Error('Invalid word list format.');
+  }
+  const delimiter = lines[0].includes(',') ? ',' : '\t';
+  const headers = lines[0].split(delimiter).map(h => h.trim());
+  const words = lines
+    .slice(1)
+    .filter(line => line.trim())
+    .map(line => {
+      const values = line.split(delimiter);
+      const wordObj = {};
+      headers.forEach((header, idx) => {
+        wordObj[header] = values[idx] ? values[idx].trim() : '';
+      });
+      return wordObj;
+    });
+
+  validateWords(words);
+  return words;
+}
+
+module.exports = { parseWordList };


### PR DESCRIPTION
## Summary
- validate required fields when parsing custom word lists
- prevent updating state and surface errors on invalid data
- add tests for JSON, CSV, and TSV parsing failure cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26d1abc64833281bf6bd0a1d4b98c