### PR TITLE
feat: add configurable scoring

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SkipForward } from 'lucide-react';
-import { GameConfig, Word, Participant, GameResults, defaultAchievements } from './types';
+import { GameConfig, Word, Participant, GameResults, defaultAchievements, defaultScoringConfig } from './types';
 import correctSoundFile from './audio/correct.mp3';
 import wrongSoundFile from './audio/wrong.mp3';
 import timeoutSoundFile from './audio/timeout.mp3';
@@ -237,10 +237,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
 
     const updatedParticipants = participants.map((p, index) => {
       if (index === currentParticipantIndex) {
-        const multipliers: Record<string, number> = { easy: 1, medium: 2, tricky: 3 };
-        const basePoints = 5;
-        const multiplier = multipliers[currentDifficulty] || 1;
-        const bonus = p.streak * 2;
+        const { basePoints, difficultyMultipliers, streakBonus } = config.scoringConfig || defaultScoringConfig;
+        const multiplier = difficultyMultipliers[currentDifficulty] || 1;
+        const bonus = p.streak * streakBonus;
         const pointsEarned = basePoints * multiplier + bonus;
         return {
           ...p,

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Word, Participant, GameConfig } from './types';
+import { Word, Participant, GameConfig, defaultScoringConfig } from './types';
 import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
 import trophyImg from './img/avatars/trophy.svg';
@@ -51,6 +51,11 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [progressionSpeed, setProgressionSpeed] = useState(1);
   const [theme, setTheme] = useState('light');
   const [teacherMode, setTeacherMode] = useState<boolean>(() => localStorage.getItem('teacherMode') === 'true');
+  const [basePoints, setBasePoints] = useState(defaultScoringConfig.basePoints);
+  const [easyMultiplier, setEasyMultiplier] = useState(defaultScoringConfig.difficultyMultipliers.easy);
+  const [mediumMultiplier, setMediumMultiplier] = useState(defaultScoringConfig.difficultyMultipliers.medium);
+  const [trickyMultiplier, setTrickyMultiplier] = useState(defaultScoringConfig.difficultyMultipliers.tricky);
+  const [streakBonus, setStreakBonus] = useState(defaultScoringConfig.streakBonus);
 
   const applyTheme = (t: string) => {
     document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
@@ -253,10 +258,28 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     }
     
     onAddCustomWords(finalWords);
-    
+
     const config: GameConfig = {
       participants: finalParticipants,
-      gameMode, timerDuration, skipPenaltyType, skipPenaltyValue, soundEnabled, effectsEnabled, difficultyLevel: initialDifficulty, progressionSpeed, musicStyle, musicVolume,
+      gameMode,
+      timerDuration,
+      skipPenaltyType,
+      skipPenaltyValue,
+      soundEnabled,
+      effectsEnabled,
+      difficultyLevel: initialDifficulty,
+      progressionSpeed,
+      musicStyle,
+      musicVolume,
+      scoringConfig: {
+        basePoints,
+        difficultyMultipliers: {
+          easy: easyMultiplier,
+          medium: mediumMultiplier,
+          tricky: trickyMultiplier,
+        },
+        streakBonus,
+      },
     };
     onStartGame(config);
   };
@@ -361,7 +384,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 <h2 className="text-2xl font-bold mb-4">Teacher Mode 👩‍🏫</h2>
                 <label className="flex items-center gap-2 text-white"><input type="checkbox" checked={teacherMode} onChange={e => setTeacherMode(e.target.checked)} /><span>Enable larger fonts and spacing</span></label>
             </div>
-             <div className="bg-white/10 p-6 rounded-lg">
+            <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4">Music 🎵</h2>
                 <div className="mb-4">
                     <label className="block mb-2">Style</label>
@@ -374,6 +397,61 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                     <input type="range" min={0} max={1} step={0.01} value={musicVolume} onChange={e => setMusicVolume(parseFloat(e.target.value))} className="w-full" />
                 </div>
             </div>
+            {teacherMode && (
+              <div className="bg-white/10 p-6 rounded-lg">
+                <h2 className="text-2xl font-bold mb-4">Scoring ⚖️</h2>
+                <div className="mb-4">
+                  <label className="block mb-2">Base Points</label>
+                  <input
+                    type="number"
+                    value={basePoints}
+                    onChange={e => setBasePoints(Number(e.target.value))}
+                    className="p-2 rounded-md bg-white/20 text-white w-full"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block mb-2">Difficulty Multipliers</label>
+                  <div className="flex gap-2">
+                    <div className="flex flex-col">
+                      <span className="text-sm">Easy</span>
+                      <input
+                        type="number"
+                        value={easyMultiplier}
+                        onChange={e => setEasyMultiplier(Number(e.target.value))}
+                        className="p-2 rounded-md bg-white/20 text-white w-20"
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm">Medium</span>
+                      <input
+                        type="number"
+                        value={mediumMultiplier}
+                        onChange={e => setMediumMultiplier(Number(e.target.value))}
+                        className="p-2 rounded-md bg-white/20 text-white w-20"
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm">Tricky</span>
+                      <input
+                        type="number"
+                        value={trickyMultiplier}
+                        onChange={e => setTrickyMultiplier(Number(e.target.value))}
+                        className="p-2 rounded-md bg-white/20 text-white w-20"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <label className="block mb-2">Streak Bonus Per Word</label>
+                  <input
+                    type="number"
+                    value={streakBonus}
+                    onChange={e => setStreakBonus(Number(e.target.value))}
+                    className="p-2 rounded-md bg-white/20 text-white w-full"
+                  />
+                </div>
+              </div>
+            )}
         </div>
         
         <div className="bg-white/10 p-6 rounded-lg mb-8 mt-8">

--- a/types.ts
+++ b/types.ts
@@ -29,6 +29,18 @@ export interface WordDatabase {
   tricky: Word[];
 }
 
+export interface ScoringConfig {
+  basePoints: number;
+  difficultyMultipliers: { [key: string]: number };
+  streakBonus: number;
+}
+
+export const defaultScoringConfig: ScoringConfig = {
+  basePoints: 5,
+  difficultyMultipliers: { easy: 1, medium: 2, tricky: 3 },
+  streakBonus: 2,
+};
+
 export interface GameConfig {
   participants: Participant[];
   gameMode: 'team' | 'individual';
@@ -43,6 +55,7 @@ export interface GameConfig {
   musicVolume: number;
   difficultyLevel: number;
   progressionSpeed: number;
+  scoringConfig: ScoringConfig;
   /** When true, the game uses the daily challenge word list */
   dailyChallenge?: boolean;
 }


### PR DESCRIPTION
## Summary
- add ScoringConfig with base points, difficulty multipliers, and streak bonus
- allow teachers to adjust scoring settings on setup screen
- compute earned points using scoringConfig in GameScreen

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve ../constants/achievements, ../constants/avatars, ../wordlists/words.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b26d1c9ca483328d7d200ea3d57442