### PR TITLE
Preload and auto-start menu music

### DIFF
--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -80,7 +80,8 @@ const SpellingBeeGame = () => {
     const musicVolume = gameConfig?.musicVolume ?? 0.5;
     const screen = gameState === 'playing' ? 'game' : 'menu';
     const trackVariant = screen === 'game' ? 'instrumental' : 'vocal';
-    useMusic(musicStyle, trackVariant, musicVolume, gameConfig?.soundEnabled ?? true, screen);
+    const soundEnabled = gameConfig?.soundEnabled ?? (localStorage.getItem('soundEnabled') !== 'false');
+    useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
 
     if (gameState === "setup") {
         return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;

--- a/utils/useMusic.ts
+++ b/utils/useMusic.ts
@@ -24,6 +24,7 @@ const useMusic = (
     instrumental: null,
     vocal: null,
   });
+  const promptRef = useRef(false);
 
   const stop = useCallback(() => {
     (['instrumental', 'vocal'] as const).forEach((v) => {
@@ -59,6 +60,7 @@ const useMusic = (
           console.warn(`Menu music file not found: ${menuSrc}`);
           menuRef.current[trackVariant] = null;
         };
+        menuAudio.load();
 
         const gameAudio = new Audio(gameSrc);
         gameAudio.loop = true;
@@ -67,6 +69,7 @@ const useMusic = (
           console.warn(`Gameplay music file not found: ${gameSrc}`);
           gameRef.current[trackVariant] = null;
         };
+        gameAudio.load();
 
         menuRef.current[trackVariant] = menuAudio;
         gameRef.current[trackVariant] = gameAudio;
@@ -99,7 +102,15 @@ const useMusic = (
     const refs = screen === 'menu' ? menuRef.current : gameRef.current;
     const track = refs[variant];
     stop();
-    track?.play().catch(() => {});
+    track?.play().catch(() => {
+      if (promptRef.current) return;
+      promptRef.current = true;
+      const enable = () => {
+        track.play().catch(() => {});
+      };
+      document.addEventListener('click', enable, { once: true });
+      alert('Click anywhere to enable audio');
+    });
   }, [screen, variant, enabled, stop]);
 
   // Clean up on unmount


### PR DESCRIPTION
## Summary
- Preload both vocal and instrumental tracks via `audio.load()`
- Start vocal menu music on initial load respecting saved sound settings
- Gracefully handle autoplay rejections by prompting the user to click to enable audio

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b26e2333e0833289c7e8661b1dc7c9