### PR TITLE
Add audio settings overlay

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -16,6 +16,7 @@ import useWordSelection, { difficultyOrder } from './utils/useWordSelection';
 import OnScreenKeyboard from './components/OnScreenKeyboard';
 import HintPanel from './components/HintPanel';
 import AvatarSelector from './components/AvatarSelector';
+import { AudioSettings } from './components/AudioSettings';
 
 const musicStyles = ['Funk', 'Country', 'Deep Bass', 'Rock', 'Jazz', 'Classical'];
 
@@ -85,6 +86,7 @@ const GameScreen: React.FC<GameScreenProps> = ({
   const [startTime] = React.useState(Date.now());
   const [currentAvatar, setCurrentAvatar] = React.useState('');
   const [darkMode, setDarkMode] = React.useState(false);
+  const [showAudioSettings, setShowAudioSettings] = React.useState(false);
 
   const playCorrect = useSound(correctSoundFile, soundEnabled);
   const playWrong = useSound(wrongSoundFile, soundEnabled);
@@ -106,6 +108,11 @@ const GameScreen: React.FC<GameScreenProps> = ({
     playTimeout();
     handleIncorrectAttempt();
   });
+  React.useEffect(() => {
+    if (!isPaused) {
+      setShowAudioSettings(false);
+    }
+  }, [isPaused]);
   React.useEffect(() => {
     if (localStorage.getItem('teacherMode') === 'true') {
       document.body.classList.add('teacher-mode');
@@ -560,9 +567,30 @@ const GameScreen: React.FC<GameScreenProps> = ({
         <SkipForward size={24} />
       </button>
 
-      {isPaused && (
-        <div className="absolute inset-0 bg-black/50 flex items-center justify-center text-6xl font-bold z-40">
-          Paused
+      {isPaused && !showAudioSettings && (
+        <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center text-6xl font-bold z-40 gap-8">
+          <div>Paused</div>
+          <button
+            onClick={() => setShowAudioSettings(true)}
+            className="bg-yellow-300 text-black px-6 py-2 rounded-lg text-2xl"
+          >
+            Audio Settings
+          </button>
+        </div>
+      )}
+
+      {showAudioSettings && isPaused && (
+        <div className="absolute inset-0 bg-black/70 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg max-w-md w-full relative">
+            <button
+              onClick={() => setShowAudioSettings(false)}
+              className="absolute top-2 right-2 text-black"
+              aria-label="Close audio settings"
+            >
+              ✕
+            </button>
+            <AudioSettings />
+          </div>
         </div>
       )}
     </div>

--- a/utils/audio.js
+++ b/utils/audio.js
@@ -1,31 +1,75 @@
 // utils/audio.js
+
 class AudioManager {
   constructor() {
     this.sounds = {};
-    this.masterVolume = 1;
-    this.muted = false;
+    if (typeof window !== 'undefined' && window.localStorage) {
+      this.volume = {
+        music: parseFloat(localStorage.getItem('musicVolume') ?? '1'),
+        sfx: parseFloat(localStorage.getItem('sfxVolume') ?? '1'),
+      };
+      this.isMusicMuted = localStorage.getItem('musicMuted') === 'true';
+      this.areSoundsMuted = localStorage.getItem('soundsMuted') === 'true';
+    } else {
+      this.volume = { music: 1, sfx: 1 };
+      this.isMusicMuted = false;
+      this.areSoundsMuted = false;
+    }
   }
 
   loadSound(key, path) {
     this.sounds[key] = new Audio(path);
   }
 
-  play(key, { volume = 1, loop = false } = {}) {
-    if (!this.sounds[key]) return;
-    
+  playSound(key, { volume = 1, loop = false } = {}) {
+    if (!this.sounds[key]) return null;
+
     const sound = this.sounds[key].cloneNode();
-    sound.volume = this.muted ? 0 : this.masterVolume * volume;
+    const effectiveVolume = this.areSoundsMuted ? 0 : this.volume.sfx * volume;
+    sound.volume = effectiveVolume;
     sound.loop = loop;
     sound.play();
     return sound;
   }
 
-  setMasterVolume(volume) {
-    this.masterVolume = Math.max(0, Math.min(1, volume));
+  setMusicVolume(volume) {
+    this.volume.music = Math.max(0, Math.min(1, volume));
+    if (typeof window !== 'undefined' && window.localStorage) {
+      localStorage.setItem('musicVolume', this.volume.music.toString());
+    }
+  }
+
+  setSfxVolume(volume) {
+    this.volume.sfx = Math.max(0, Math.min(1, volume));
+    if (typeof window !== 'undefined' && window.localStorage) {
+      localStorage.setItem('sfxVolume', this.volume.sfx.toString());
+    }
+  }
+
+  toggleMusic() {
+    this.isMusicMuted = !this.isMusicMuted;
+    if (typeof window !== 'undefined' && window.localStorage) {
+      localStorage.setItem('musicMuted', this.isMusicMuted.toString());
+    }
+    return !this.isMusicMuted;
+  }
+
+  toggleSound() {
+    this.areSoundsMuted = !this.areSoundsMuted;
+    if (typeof window !== 'undefined' && window.localStorage) {
+      localStorage.setItem('soundsMuted', this.areSoundsMuted.toString());
+    }
+    return !this.areSoundsMuted;
   }
 
   toggleMute() {
-    this.muted = !this.muted;
+    const muted = this.isMusicMuted && this.areSoundsMuted;
+    this.isMusicMuted = !muted;
+    this.areSoundsMuted = !muted;
+    if (typeof window !== 'undefined' && window.localStorage) {
+      localStorage.setItem('musicMuted', this.isMusicMuted.toString());
+      localStorage.setItem('soundsMuted', this.areSoundsMuted.toString());
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- show AudioSettings overlay from the game pause menu
- track music and SFX volume/mute via a shared audio manager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27350dd648332988e09565809462f