### PR TITLE
Add session history tracking and screen

### DIFF
--- a/HistoryScreen.tsx
+++ b/HistoryScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+
+interface HistoryEntry {
+  date: string;
+  score: number;
+  duration?: number;
+}
+
+interface HistoryScreenProps {
+  onBack: () => void;
+}
+
+const HistoryScreen: React.FC<HistoryScreenProps> = ({ onBack }) => {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+
+  useEffect(() => {
+    const stored: HistoryEntry[] = JSON.parse(localStorage.getItem('sessionHistory') || '[]');
+    setHistory(stored.reverse());
+    if (localStorage.getItem('teacherMode') === 'true') {
+      document.body.classList.add('teacher-mode');
+    } else {
+      document.body.classList.remove('teacher-mode');
+    }
+  }, []);
+
+  const handleClear = () => {
+    localStorage.removeItem('sessionHistory');
+    setHistory([]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white text-center flex flex-col items-center justify-center">
+      <h1 className="text-6xl font-bold mb-8 text-yellow-300">\uD83D\uDCDC Session History</h1>
+      <div className="bg-white/10 p-8 rounded-lg w-full max-w-md scorecard">
+        {history.length === 0 ? (
+          <div className="text-xl">No history yet.</div>
+        ) : (
+          <ol className="text-xl space-y-2">
+            {history.map((entry, index) => (
+              <li key={index} className="flex justify-between items-center py-1">
+                <span>{new Date(entry.date).toLocaleString()}</span>
+                <span className="text-yellow-300">{entry.score}</span>
+                <span>{entry.duration ?? 0}s</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+      <div className="flex gap-4 mt-8 flex-wrap justify-center">
+        <button onClick={handleClear} className="bg-red-500 hover:bg-red-600 px-8 py-4 rounded-xl text-2xl font-bold">Clear History</button>
+        <button onClick={onBack} className="bg-blue-500 hover:bg-blue-600 px-8 py-4 rounded-xl text-2xl font-bold">Back</button>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryScreen;

--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -52,8 +52,10 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
   }, [results, config.dailyChallenge, bonus]);
 
   useEffect(() => {
-    const history: { date: string; score: number }[] = JSON.parse(localStorage.getItem('sessionHistory') || '[]');
-    history.push({ date: new Date().toISOString(), score: totalScore });
+    const history: { date: string; score: number; duration?: number }[] = JSON.parse(
+      localStorage.getItem('sessionHistory') || '[]'
+    );
+    history.push({ date: new Date().toISOString(), score: totalScore, duration: results.duration });
     localStorage.setItem('sessionHistory', JSON.stringify(history));
 
     const storedBest = Number(localStorage.getItem('bestClassScore') || '0');

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -13,9 +13,10 @@ interface SetupScreenProps {
   onStartGame: (config: GameConfig) => void;
   onAddCustomWords: (words: Word[]) => void;
   onViewAchievements: () => void;
+  onViewHistory: () => void;
 }
 
-const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements }) => {
+const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements, onViewHistory }) => {
   const avatars = [beeImg, bookImg, trophyImg];
   const getRandomAvatar = () => avatars[Math.floor(Math.random() * avatars.length)];
 
@@ -493,8 +494,9 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             <button onClick={() => handleStart(false)} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Custom Game</button>
             <button onClick={() => handleStart(true)} className="w-full bg-orange-500 hover:bg-orange-600 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Session Challenge</button>
         </div>
-        <div className="mt-4 text-center">
+        <div className="mt-4 text-center flex gap-4 justify-center">
             <button onClick={onViewAchievements} className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View Achievements</button>
+            <button onClick={onViewHistory} className="bg-green-500 hover:bg-green-600 text-white px-6 py-3 rounded-xl text-xl font-bold">History</button>
         </div>
       </div>
     </div>

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -5,6 +5,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import HistoryScreen from './HistoryScreen';
 import useMusic from './utils/useMusic';
 
 // --- Main App Component ---
@@ -71,6 +72,10 @@ const SpellingBeeGame = () => {
         setGameState("achievements");
     };
 
+    const handleViewHistory = () => {
+        setGameState("history");
+    };
+
     const handleBackToSetup = () => {
         setGameState("setup");
     };
@@ -89,7 +94,7 @@ const SpellingBeeGame = () => {
     useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
 
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
+        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} onViewHistory={handleViewHistory} />;
     }
     if (gameState === "playing") {
         return (
@@ -115,6 +120,9 @@ const SpellingBeeGame = () => {
     }
     if (gameState === "achievements") {
         return <AchievementsScreen onBack={handleBackToSetup} />;
+    }
+    if (gameState === "history") {
+        return <HistoryScreen onBack={handleBackToSetup} />;
     }
     return null;
 };


### PR DESCRIPTION
## Summary
- Track game duration in session history and expose through a new History screen
- Allow viewing and clearing of past sessions from Setup
- Wire up History view in main app state machine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b273e6c3408332abe0fb88a11ca1f9