### PR TITLE
feat: add achievement notifications

### DIFF
--- a/AchievementsScreen.tsx
+++ b/AchievementsScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { achievements } from '@constants/achievements';
-import { defaultAchievements } from './types';
 
 interface AchievementsScreenProps {
   onBack: () => void;
@@ -22,16 +21,18 @@ const AchievementBadge = ({ unlocked, title, description, icon }: AchievementPro
 );
 
 const AchievementsScreen: React.FC<AchievementsScreenProps> = ({ onBack }) => {
-  const [userAchievements, setUserAchievements] = useState<string[]>([]);
-
-  const unlocked = React.useMemo(() => {
-    if (typeof window === 'undefined') return [] as string[];
+  const [unlocked, setUnlocked] = useState<string[]>(() => {
+    if (typeof window === 'undefined') return [];
     try {
       return JSON.parse(localStorage.getItem('unlockedAchievements') || '[]');
     } catch {
       return [];
     }
-  }, []);
+  });
+
+  React.useEffect(() => {
+    localStorage.setItem('unlockedAchievements', JSON.stringify(unlocked));
+  }, [unlocked]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-600 to-teal-800 p-8 text-white">

--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -16,6 +16,7 @@ import useWordSelection, { difficultyOrder } from './utils/useWordSelection';
 import OnScreenKeyboard from './components/OnScreenKeyboard';
 import HintPanel from './components/HintPanel';
 import AvatarSelector from './components/AvatarSelector';
+import { useNotifications, NotificationContainer } from './components/Notification.jsx';
 
 const musicStyles = ['Funk', 'Country', 'Deep Bass', 'Rock', 'Jazz', 'Classical'];
 
@@ -80,11 +81,12 @@ const GameScreen: React.FC<GameScreenProps> = ({
       return [];
     }
   });
-  const [toast, setToast] = React.useState('');
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
   const [startTime] = React.useState(Date.now());
   const [currentAvatar, setCurrentAvatar] = React.useState('');
   const [darkMode, setDarkMode] = React.useState(false);
+
+  const { notifications, addNotification, removeNotification } = useNotifications();
 
   const playCorrect = useSound(correctSoundFile, soundEnabled);
   const playWrong = useSound(wrongSoundFile, soundEnabled);
@@ -292,9 +294,9 @@ const GameScreen: React.FC<GameScreenProps> = ({
         const updatedUnlocked = [...unlockedAchievements, ...newlyUnlocked.map(a => a.id)];
         setUnlockedAchievements(updatedUnlocked);
         localStorage.setItem('unlockedAchievements', JSON.stringify(updatedUnlocked));
-        const first = newlyUnlocked[0];
-        setToast(`Achievement unlocked: ${first.icon} ${first.name}!`);
-        setTimeout(() => setToast(''), 3000);
+        newlyUnlocked.forEach(ach => {
+          addNotification(`Achievement unlocked: ${ach.icon} ${ach.name}!`);
+        });
       }
       
       playCorrect();
@@ -406,11 +408,7 @@ const GameScreen: React.FC<GameScreenProps> = ({
         aria-hidden="true"
         tabIndex={-1}
       />
-      {toast && (
-        <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-lg z-50">
-          {toast}
-        </div>
-      )}
+      <NotificationContainer notifications={notifications} onRemove={removeNotification} />
       <div className="absolute top-8 left-8 flex gap-8 items-center">
         <img src="img/bee.svg" alt="Bee icon" className="w-12 h-12" />
         {participants.map((p, index) => (


### PR DESCRIPTION
## Summary
- show achievement notifications during gameplay
- persist unlocked achievements across screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b273e3902883328bb3470e60bb04b9