### PR TITLE
Add practice mode for missed words

### DIFF
--- a/PracticeScreen.tsx
+++ b/PracticeScreen.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { Word } from './types';
+import OnScreenKeyboard from './components/OnScreenKeyboard';
+import HintPanel from './components/HintPanel';
+import { speak } from './utils/tts';
+
+interface PracticeScreenProps {
+  words: Word[];
+  onBack: () => void;
+  soundEnabled?: boolean;
+}
+
+const PracticeScreen: React.FC<PracticeScreenProps> = ({ words, onBack, soundEnabled = true }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [letters, setLetters] = useState<string[]>([]);
+  const [feedback, setFeedback] = useState('');
+
+  const currentWord = words[currentIndex];
+
+  useEffect(() => {
+    if (currentWord) {
+      setLetters(Array(currentWord.word.length).fill(''));
+      speak(currentWord.word);
+    }
+  }, [currentWord]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!currentWord) return;
+      if (/^[a-zA-Z]$/.test(e.key)) {
+        typeLetter(e.key.toLowerCase());
+      } else if (e.key === 'Backspace') {
+        handleBackspace();
+      } else if (e.key === 'Enter') {
+        handleSubmit();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [letters, currentWord]);
+
+  const typeLetter = (letter: string) => {
+    setLetters(prev => {
+      const index = prev.findIndex(l => l === '');
+      if (index === -1) return prev;
+      const updated = [...prev];
+      updated[index] = letter;
+      return updated;
+    });
+  };
+
+  const handleBackspace = () => {
+    setLetters(prev => {
+      const index = prev.slice().reverse().findIndex(l => l !== '');
+      if (index === -1) return prev;
+      const updated = [...prev];
+      updated[prev.length - 1 - index] = '';
+      return updated;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (!currentWord) return;
+    const attempt = letters.join('').toLowerCase();
+    if (attempt === currentWord.word.toLowerCase()) {
+      setFeedback('Correct!');
+      setTimeout(() => {
+        setFeedback('');
+        setCurrentIndex(i => i + 1);
+      }, 1000);
+    } else {
+      setFeedback('Try again!');
+    }
+  };
+
+  if (!currentWord) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white flex flex-col items-center justify-center text-center">
+        <h1 className="text-4xl font-bold mb-6">All words practiced!</h1>
+        <button onClick={onBack} className="bg-blue-500 hover:bg-blue-600 px-8 py-4 rounded-lg text-2xl font-bold">🔙 Back to Results</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white flex flex-col items-center text-center">
+      <h1 className="text-4xl font-bold mb-6">Practice Missed Words</h1>
+      <div className="text-3xl font-mono mb-4">{letters.map(l => l || '_').join(' ')}</div>
+      <HintPanel
+        word={currentWord}
+        participantPoints={999}
+        participantIndex={0}
+        spendPoints={() => {}}
+        isTeamMode={false}
+        showWord={true}
+        onHintUsed={() => {}}
+        onExtraAttempt={() => {}}
+      />
+      <OnScreenKeyboard
+        onLetter={typeLetter}
+        onBackspace={handleBackspace}
+        onSubmit={handleSubmit}
+        soundEnabled={soundEnabled}
+      />
+      {feedback && (
+        <div className={`mt-4 text-2xl ${feedback === 'Correct!' ? 'text-green-400' : 'text-red-400'}`}>{feedback}</div>
+      )}
+      <button onClick={onBack} className="mt-8 bg-blue-500 hover:bg-blue-600 px-8 py-4 rounded-lg text-2xl font-bold">⬅️ Back</button>
+    </div>
+  );
+};
+
+export default PracticeScreen;

--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { GameResults, GameConfig, LeaderboardEntry } from './types';
+import { GameResults, GameConfig, LeaderboardEntry, Word } from './types';
 import applauseSoundFile from './audio/applause.mp3';
 import { launchConfetti } from './utils/confetti';
 import { recordDailyCompletion, StreakInfo } from './DailyChallenge';
@@ -10,9 +10,10 @@ interface ResultsScreenProps {
   config: GameConfig;
   onRestart: () => void;
   onViewLeaderboard: () => void;
+  onPractice: (words: Word[]) => void;
 }
 
-const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestart, onViewLeaderboard }) => {
+const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestart, onViewLeaderboard, onPractice }) => {
   const applauseAudio = useRef<HTMLAudioElement>(new Audio(applauseSoundFile));
   const totalScore = results.participants.reduce((sum, p) => sum + p.points, 0);
   const [bestClassScore, setBestClassScore] = useState(0);
@@ -156,6 +157,14 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
         <button onClick={onViewLeaderboard} className="bg-purple-500 hover:bg-purple-600 px-8 py-5 rounded-xl text-2xl font-bold">
             📈 View Leaderboard
         </button>
+        {results.missedWords && results.missedWords.length > 0 && (
+          <button
+            onClick={() => onPractice(results.missedWords)}
+            className="bg-yellow-500 hover:bg-yellow-600 px-8 py-5 rounded-xl text-2xl font-bold"
+          >
+            📝 Practice Missed Words
+          </button>
+        )}
         <button onClick={onRestart} className="bg-blue-500 hover:bg-blue-600 px-10 py-5 rounded-xl text-2xl font-bold">
             🔄 Play Again
         </button>

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -5,7 +5,9 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import PracticeScreen from './PracticeScreen';
 import useMusic from './utils/useMusic';
+import { Word } from './types';
 
 // --- Main App Component ---
 const SpellingBeeGame = () => {
@@ -18,6 +20,7 @@ const SpellingBeeGame = () => {
     const [musicVolume, setMusicVolume] = useState(0.5);
     const [soundEnabled, setSoundEnabled] = useState(true);
     const [isMusicPlaying, setIsMusicPlaying] = useState(true);
+    const [practiceWords, setPracticeWords] = useState<Word[]>([]);
 
     useEffect(() => {
         fetch('words.json')
@@ -71,6 +74,11 @@ const SpellingBeeGame = () => {
         setGameState("achievements");
     };
 
+    const handlePracticeMissedWords = (words: Word[]) => {
+        setPracticeWords(words);
+        setGameState("practice");
+    };
+
     const handleBackToSetup = () => {
         setGameState("setup");
     };
@@ -107,8 +115,11 @@ const SpellingBeeGame = () => {
             />
         );
     }
+    if (gameState === "practice") {
+        return <PracticeScreen words={practiceWords} onBack={() => setGameState('results')} soundEnabled={soundEnabled} />;
+    }
     if (gameState === "results") {
-        return <ResultsScreen results={gameResults} config={gameConfig} onRestart={handleRestart} onViewLeaderboard={handleViewLeaderboard} />;
+        return <ResultsScreen results={gameResults} config={gameConfig} onRestart={handleRestart} onViewLeaderboard={handleViewLeaderboard} onPractice={handlePracticeMissedWords} />;
     }
     if (gameState === "leaderboard") {
         return <LeaderboardScreen onBack={handleBackToSetup} />;


### PR DESCRIPTION
## Summary
- Add PracticeScreen for reviewing missed words using HintPanel and OnScreenKeyboard
- Add "Practice Missed Words" button on results screen
- Wire new practice game state and navigation in main app

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b273e14e2083328fadee7020e8c742