### PR TITLE
feat: add theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+const themes = ['light', 'dark', 'honeycomb'] as const;
+type Theme = typeof themes[number];
+
+const ThemeToggle: React.FC = () => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  const applyTheme = (t: Theme) => {
+    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
+    document.body.classList.add(`theme-${t}`);
+    localStorage.setItem('theme', t);
+  };
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme') as Theme | null;
+    if (saved && themes.includes(saved)) {
+      setTheme(saved);
+      applyTheme(saved);
+    } else {
+      applyTheme('light');
+    }
+  }, []);
+
+  const handleClick = () => {
+    const idx = themes.indexOf(theme);
+    const next = themes[(idx + 1) % themes.length];
+    setTheme(next);
+    applyTheme(next);
+  };
+
+  const icon = theme === 'light' ? '🌞' : theme === 'dark' ? '🌙' : '🍯';
+
+  return (
+    <button className="theme-toggle" onClick={handleClick} aria-label="Toggle theme">
+      {icon}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -5,6 +5,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import ThemeToggle from './components/ThemeToggle';
 import useMusic from './utils/useMusic';
 
 // --- Main App Component ---
@@ -91,11 +92,17 @@ const SpellingBeeGame = () => {
     const trackVariant = screen === 'game' ? 'instrumental' : 'vocal';
     useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
 
+    let content;
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
-    }
-    if (gameState === "playing") {
-        return (
+        content = (
+            <SetupScreen
+                onStartGame={handleStartGame}
+                onAddCustomWords={handleAddCustomWords}
+                onViewAchievements={handleViewAchievements}
+            />
+        );
+    } else if (gameState === "playing") {
+        content = (
             <GameScreen
                 config={gameConfig}
                 onEndGame={handleEndGame}
@@ -110,17 +117,29 @@ const SpellingBeeGame = () => {
                 onQuit={handleQuitToSetup}
             />
         );
+    } else if (gameState === "results") {
+        content = (
+            <ResultsScreen
+                results={gameResults}
+                config={gameConfig}
+                onRestart={handleRestart}
+                onViewLeaderboard={handleViewLeaderboard}
+            />
+        );
+    } else if (gameState === "leaderboard") {
+        content = <LeaderboardScreen onBack={handleBackToSetup} />;
+    } else if (gameState === "achievements") {
+        content = <AchievementsScreen onBack={handleBackToSetup} />;
+    } else {
+        content = null;
     }
-    if (gameState === "results") {
-        return <ResultsScreen results={gameResults} config={gameConfig} onRestart={handleRestart} onViewLeaderboard={handleViewLeaderboard} />;
-    }
-    if (gameState === "leaderboard") {
-        return <LeaderboardScreen onBack={handleBackToSetup} />;
-    }
-    if (gameState === "achievements") {
-        return <AchievementsScreen onBack={handleBackToSetup} />;
-    }
-    return null;
+
+    return (
+        <>
+            {content}
+            <ThemeToggle />
+        </>
+    );
 };
 
 // --- App Rendering ---


### PR DESCRIPTION
## Summary
- add ThemeToggle component cycling between light, dark, and honeycomb themes
- show theme toggle button on every screen and persist preference in localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27a636a648332b3efe5188eba8b24