### PR TITLE
Add circular countdown timer component

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -22,6 +22,7 @@ import useWordSelection, { difficultyOrder } from "./utils/useWordSelection";
 import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
+import CircularTimer from "./components/CircularTimer";
 import { audioManager } from "./utils/audio";
 
 interface GameScreenProps {
@@ -480,12 +481,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       )}
 
       <div className="absolute top-8 right-8 text-center z-50">
-        <div
-          className={`text-6xl font-bold ${timeLeft <= 10 ? "text-red-500" : "text-yellow-300"}`}
-        >
-          {timeLeft}
-        </div>
-        <div className="text-lg">seconds left</div>
+        <CircularTimer timeLeft={timeLeft} total={config.timerDuration} />
         <button
           onClick={isPaused ? resumeTimer : pauseTimer}
           className="mt-2 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"

--- a/components/CircularTimer.tsx
+++ b/components/CircularTimer.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+interface CircularTimerProps {
+  timeLeft: number;
+  total: number;
+  warningThreshold?: number;
+}
+
+const CircularTimer: React.FC<CircularTimerProps> = ({
+  timeLeft,
+  total,
+  warningThreshold = 10,
+}) => {
+  const radius = 50;
+  const stroke = 8;
+  const normalizedRadius = radius - stroke / 2;
+  const circumference = normalizedRadius * 2 * Math.PI;
+  const progress = timeLeft / total;
+  const strokeDashoffset = circumference - progress * circumference;
+  const isWarning = timeLeft <= warningThreshold;
+
+  return (
+    <svg
+      height={radius * 2}
+      width={radius * 2}
+      className="transform -rotate-90 w-32 h-32"
+    >
+      <circle
+        stroke="currentColor"
+        fill="transparent"
+        strokeWidth={stroke}
+        r={normalizedRadius}
+        cx={radius}
+        cy={radius}
+        className="text-gray-700"
+      />
+      <circle
+        stroke="currentColor"
+        fill="transparent"
+        strokeWidth={stroke}
+        r={normalizedRadius}
+        cx={radius}
+        cy={radius}
+        strokeDasharray={`${circumference} ${circumference}`}
+        style={{ strokeDashoffset }}
+        className={`${isWarning ? 'text-red-500 animate-pulse' : 'text-yellow-300'} transition-stroke`}
+        strokeLinecap="round"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="text-3xl font-bold fill-current text-white rotate-90"
+      >
+        {timeLeft}
+      </text>
+    </svg>
+  );
+};
+
+export default CircularTimer;


### PR DESCRIPTION
## Summary
- implement `CircularTimer` SVG ring countdown that flashes red near end
- use `CircularTimer` in `GameScreen` replacing text timer

## Testing
- `npm test` *(fails: npm: command not found)*
- `apt-get update` *(fails: The repository 'https://mise.jdx.dev/deb stable Release' does not have a Release file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b27a655c5883328fa618d2c3979b8d