### PR TITLE
Highlight current player in scorecards

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -453,7 +453,19 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       <div className="absolute top-8 left-8 flex gap-8 items-center">
         <img src="img/bee.svg" alt="Bee icon" className="w-12 h-12" />
         {participants.map((p, index) => (
-          <div key={index} className="text-center scorecard">
+          <div
+            key={index}
+            className={`text-center scorecard ${
+              index === currentParticipantIndex ? "active-player" : ""
+            }`}
+          >
+            {p.avatar && (
+              <img
+                src={p.avatar}
+                alt={`${p.name} avatar`}
+                className="w-12 h-12 mx-auto mb-2 rounded-full"
+              />
+            )}
             <div className="text-2xl font-bold">{p.name}</div>
             <div className="text-4xl font-bold text-yellow-300">
               {"❤️".repeat(p.lives)}

--- a/style.css
+++ b/style.css
@@ -59,6 +59,25 @@ body.teacher-mode .scorecard {
     margin-bottom: 1.5em;
 }
 
+.scorecard {
+    transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.scorecard img {
+    transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.scorecard.active-player {
+    transform: scale(1.05);
+    box-shadow: 0 0 10px var(--primary-color);
+    border-radius: 0.5rem;
+}
+
+.scorecard.active-player img {
+    transform: scale(1.1);
+    box-shadow: 0 0 10px var(--primary-color);
+}
+
 img,
 video {
     max-width: 100%;


### PR DESCRIPTION
## Summary
- Mark active participant's scorecard by comparing index to currentParticipantIndex
- Add avatars with conditional highlighting class for active player
- Introduce active-player styles for glowing emphasis across themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27a66d3cc83328dd3a65784f60d25