### PR TITLE
Add coin rewards and cosmetic shop

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -86,7 +86,28 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const [toast, setToast] = React.useState("");
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
   const [startTime] = React.useState(Date.now());
-  const [currentAvatar, setCurrentAvatar] = React.useState("");
+  const [coins, setCoins] = React.useState<number>(() => {
+    if (typeof window === "undefined") return 0;
+    const stored = localStorage.getItem("coins");
+    return stored ? parseInt(stored, 10) : 0;
+  });
+  const [ownedAvatars] = React.useState<string[]>(() => {
+    if (typeof window === "undefined") return ["bee", "book", "trophy"];
+    try {
+      return JSON.parse(
+        localStorage.getItem("ownedAvatars") || "[\"bee\",\"book\",\"trophy\"]",
+      );
+    } catch {
+      return ["bee", "book", "trophy"];
+    }
+  });
+  const [currentAvatar, setCurrentAvatar] = React.useState(() => {
+    if (typeof window === "undefined") return "";
+    return localStorage.getItem("equippedAvatar") || "";
+  });
+  React.useEffect(() => {
+    localStorage.setItem("equippedAvatar", currentAvatar);
+  }, [currentAvatar]);
 
   const playCorrect = useSound(correctSoundFile, config.soundEnabled);
   const playWrong = useSound(wrongSoundFile, config.soundEnabled);
@@ -328,6 +349,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
 
       playCorrect();
 
+      const coinReward = 1;
+      const newCoins = coins + coinReward;
+      setCoins(newCoins);
+      localStorage.setItem("coins", String(newCoins));
+
       const prefersReducedMotion = window.matchMedia(
         "(prefers-reduced-motion: reduce)",
       ).matches;
@@ -506,6 +532,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       <AvatarSelector
         currentAvatar={currentAvatar}
         onSelect={(avatar) => setCurrentAvatar(avatar)}
+        availableAvatars={ownedAvatars}
       />
 
       {currentWord && (

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -11,9 +11,10 @@ interface SetupScreenProps {
   onStartGame: (config: GameConfig) => void;
   onAddCustomWords: (words: Word[]) => void;
   onViewAchievements: () => void;
+  onViewShop: () => void;
 }
 
-const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements }) => {
+const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements, onViewShop }) => {
   const avatars = [beeImg, bookImg, trophyImg];
   const getRandomAvatar = () => avatars[Math.floor(Math.random() * avatars.length)];
 
@@ -569,8 +570,9 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             <button onClick={() => handleStart(false)} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Custom Game</button>
             <button onClick={() => handleStart(true)} className="w-full bg-orange-500 hover:bg-orange-600 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Session Challenge</button>
         </div>
-        <div className="mt-4 text-center">
+        <div className="mt-4 flex justify-center gap-4">
             <button onClick={onViewAchievements} className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View Achievements</button>
+            <button onClick={onViewShop} className="bg-green-500 hover:bg-green-600 text-white px-6 py-3 rounded-xl text-xl font-bold">Shop</button>
         </div>
       </div>
     </div>

--- a/ShopScreen.tsx
+++ b/ShopScreen.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import AvatarSelector from "./components/AvatarSelector";
+
+interface ShopScreenProps {
+  onBack: () => void;
+}
+
+interface ShopItem {
+  id: string;
+  name: string;
+  icon: string;
+  price: number;
+  type: "avatar" | "accessory";
+}
+
+const shopItems: ShopItem[] = [
+  { id: "wizard", name: "Wizard Avatar", icon: "/img/avatars/bee.svg", price: 50, type: "avatar" },
+  { id: "top-hat", name: "Top Hat", icon: "/img/avatars/book.svg", price: 30, type: "accessory" },
+];
+
+const ShopScreen: React.FC<ShopScreenProps> = ({ onBack }) => {
+  const [coins, setCoins] = React.useState(() => {
+    if (typeof window === "undefined") return 0;
+    const stored = localStorage.getItem("coins");
+    return stored ? parseInt(stored, 10) : 0;
+  });
+
+  const [ownedAvatars, setOwnedAvatars] = React.useState<string[]>(() => {
+    if (typeof window === "undefined") return ["bee", "book", "trophy"];
+    try {
+      return JSON.parse(
+        localStorage.getItem("ownedAvatars") || "[\"bee\",\"book\",\"trophy\"]",
+      );
+    } catch {
+      return ["bee", "book", "trophy"];
+    }
+  });
+
+  const [ownedAccessories, setOwnedAccessories] = React.useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      return JSON.parse(localStorage.getItem("ownedAccessories") || "[]");
+    } catch {
+      return [];
+    }
+  });
+
+  const [currentAvatar, setCurrentAvatar] = React.useState(() => {
+    if (typeof window === "undefined") return "";
+    return localStorage.getItem("equippedAvatar") || "";
+  });
+
+  React.useEffect(() => {
+    localStorage.setItem("equippedAvatar", currentAvatar);
+  }, [currentAvatar]);
+
+  const purchaseItem = (item: ShopItem) => {
+    if (coins < item.price) return;
+    const newCoins = coins - item.price;
+    setCoins(newCoins);
+    localStorage.setItem("coins", String(newCoins));
+
+    if (item.type === "avatar" && !ownedAvatars.includes(item.id)) {
+      const updated = [...ownedAvatars, item.id];
+      setOwnedAvatars(updated);
+      localStorage.setItem("ownedAvatars", JSON.stringify(updated));
+    }
+    if (item.type === "accessory" && !ownedAccessories.includes(item.id)) {
+      const updated = [...ownedAccessories, item.id];
+      setOwnedAccessories(updated);
+      localStorage.setItem("ownedAccessories", JSON.stringify(updated));
+    }
+  };
+
+  const isOwned = (item: ShopItem) => {
+    return item.type === "avatar"
+      ? ownedAvatars.includes(item.id)
+      : ownedAccessories.includes(item.id);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-600 to-pink-500 text-white p-8">
+      <button
+        onClick={onBack}
+        className="mb-4 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+      >
+        Back
+      </button>
+      <h1 className="text-3xl font-bold mb-4">Shop</h1>
+      <div className="mb-4">Coins: {coins}</div>
+
+      <h2 className="text-2xl font-bold mb-2">Your Avatar</h2>
+      <AvatarSelector
+        currentAvatar={currentAvatar}
+        onSelect={setCurrentAvatar}
+        availableAvatars={ownedAvatars}
+      />
+
+      <h2 className="text-2xl font-bold mt-8 mb-2">Items</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {shopItems.map((item) => (
+          <div
+            key={item.id}
+            className="bg-white/10 p-4 rounded-lg flex items-center justify-between"
+          >
+            <div className="flex items-center gap-4">
+              <img src={item.icon} alt={item.name} className="w-16 h-16" />
+              <div>
+                <div className="font-bold">{item.name}</div>
+                <div>{item.price} coins</div>
+              </div>
+            </div>
+            {isOwned(item) ? (
+              <span className="text-green-400 font-bold">Owned</span>
+            ) : (
+              <button
+                onClick={() => purchaseItem(item)}
+                className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
+              >
+                Buy
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ShopScreen;
+

--- a/components/AvatarSelector.tsx
+++ b/components/AvatarSelector.tsx
@@ -4,12 +4,21 @@ import { avatars } from '@constants/avatars';
 type AvatarSelectorProps = {
   currentAvatar: string;
   onSelect: (avatar: string) => void;
+  availableAvatars?: string[];
 };
 
-export default function AvatarSelector({ currentAvatar, onSelect }: { currentAvatar: string; onSelect: (avatar: string) => void }) {
+export default function AvatarSelector({ currentAvatar, onSelect, availableAvatars }: AvatarSelectorProps) {
+  const displayAvatars = availableAvatars
+    ? Object.fromEntries(
+        availableAvatars
+          .filter((key) => avatars[key])
+          .map((key) => [key, avatars[key]])
+      )
+    : avatars;
+
   return (
     <div className="avatar-selector">
-      {Object.entries(avatars).map(([key, avatar]) => (
+      {Object.entries(displayAvatars).map(([key, avatar]) => (
         <button
           key={key}
           className={`avatar-option ${currentAvatar === key ? 'selected' : ''}`}

--- a/constants/avatars.ts
+++ b/constants/avatars.ts
@@ -1,5 +1,7 @@
 export const avatars = {
-  bee: '/img/avatars/bee.svg',
-  book: '/img/avatars/book.svg',
-  trophy: '/img/avatars/trophy.svg'
+  bee: { name: 'Bee', icon: '/img/avatars/bee.svg' },
+  book: { name: 'Book', icon: '/img/avatars/book.svg' },
+  trophy: { name: 'Trophy', icon: '/img/avatars/trophy.svg' },
+  wizard: { name: 'Wizard', icon: '/img/avatars/bee.svg' },
+  ninja: { name: 'Ninja', icon: '/img/avatars/book.svg' },
 };

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -5,6 +5,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import ShopScreen from './ShopScreen';
 import useMusic from './utils/useMusic';
 
 // --- Main App Component ---
@@ -70,6 +71,10 @@ const SpellingBeeGame = () => {
         setGameState("achievements");
     };
 
+    const handleViewShop = () => {
+        setGameState("shop");
+    };
+
     const handleBackToSetup = () => {
         setGameState("setup");
     };
@@ -92,7 +97,7 @@ const SpellingBeeGame = () => {
     useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
 
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
+        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} onViewShop={handleViewShop} />;
     }
     if (gameState === "playing") {
         return (
@@ -119,6 +124,9 @@ const SpellingBeeGame = () => {
     }
     if (gameState === "achievements") {
         return <AchievementsScreen onBack={handleBackToSetup} />;
+    }
+    if (gameState === "shop") {
+        return <ShopScreen onBack={handleBackToSetup} />;
     }
     return null;
 };


### PR DESCRIPTION
## Summary
- reward players with coins for correct spellings and persist total in localStorage
- add shop interface with premium avatars/accessories and avatar equipping
- integrate shop navigation and restrict avatar selection to owned cosmetics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27ae6b544833298dd87225c7ad43a