### PR TITLE
feat: add daily streak bonuses

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -24,6 +24,8 @@ import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
 import { audioManager } from "./utils/audio";
 
+const STREAK_MILESTONES = [3, 7, 14, 30];
+
 interface GameScreenProps {
   config: GameConfig;
   onEndGame: (results: GameResults) => void;
@@ -87,6 +89,17 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
   const [startTime] = React.useState(Date.now());
   const [currentAvatar, setCurrentAvatar] = React.useState("");
+
+  React.useEffect(() => {
+    const streak = Number(localStorage.getItem("streak") || "0");
+    const last = Number(localStorage.getItem("lastStreakMilestone") || "0");
+    if (STREAK_MILESTONES.includes(streak) && streak !== last) {
+      const bonus = streak * 10;
+      setParticipants((ps) => ps.map((p) => ({ ...p, points: p.points + bonus })));
+      setToast(`🔥 ${streak}-day streak bonus! +${bonus} points`);
+      localStorage.setItem("lastStreakMilestone", String(streak));
+    }
+  }, []);
 
   const playCorrect = useSound(correctSoundFile, config.soundEnabled);
   const playWrong = useSound(wrongSoundFile, config.soundEnabled);

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
+import { Flame } from 'lucide-react';
 import { GameConfig, Word } from './types';
 import { parseWordList } from './utils/parseWordList';
+import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
+import trophyImg from './img/avatars/trophy.svg';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -11,9 +14,10 @@ interface SetupScreenProps {
   onStartGame: (config: GameConfig) => void;
   onAddCustomWords: (words: Word[]) => void;
   onViewAchievements: () => void;
+  streak: number;
 }
 
-const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements }) => {
+const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements, streak }) => {
   const avatars = [beeImg, bookImg, trophyImg];
   const getRandomAvatar = () => avatars[Math.floor(Math.random() * avatars.length)];
 
@@ -373,6 +377,10 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 <h1 className="text-4xl md:text-6xl font-bold text-yellow-300">🏆 SPELLING BEE CHAMPIONSHIP</h1>
             </div>
             <p className="text-xl md:text-2xl">Get ready to spell your way to victory!</p>
+            <div className="flex items-center justify-center text-orange-400 mt-2">
+              <Flame className="w-5 h-5 mr-1" />
+              <span>{streak} day{streak === 1 ? '' : 's'} streak</span>
+            </div>
         </div>
 
         <div className="bg-white/10 p-6 rounded-lg mb-8">

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -18,6 +18,24 @@ const SpellingBeeGame = () => {
     const [musicVolume, setMusicVolume] = useState(0.5);
     const [soundEnabled, setSoundEnabled] = useState(true);
     const [isMusicPlaying, setIsMusicPlaying] = useState(true);
+    const [streak] = useState(() => {
+        const today = new Date().toISOString().split('T')[0];
+        const lastPlayed = localStorage.getItem('lastPlayed');
+        let current = Number(localStorage.getItem('streak') || '0');
+        if (!lastPlayed) {
+            current = 1;
+        } else {
+            const diff = (new Date(today).getTime() - new Date(lastPlayed).getTime()) / (1000 * 60 * 60 * 24);
+            if (diff === 1) {
+                current += 1;
+            } else if (diff > 1) {
+                current = 1;
+            }
+        }
+        localStorage.setItem('streak', String(current));
+        localStorage.setItem('lastPlayed', today);
+        return current;
+    });
 
     useEffect(() => {
         fetch('words.json')
@@ -92,7 +110,7 @@ const SpellingBeeGame = () => {
     useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
 
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
+        return <SetupScreen streak={streak} onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
     }
     if (gameState === "playing") {
         return (


### PR DESCRIPTION
## Summary
- track daily streak on app start and store in localStorage
- show streak with flame icon on setup screen
- grant bonus points on hitting daily streak milestones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27ae8b26c83329a71db80778852f0