### PR TITLE
Add scoreboard sharing and best score display

### DIFF
--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -1,9 +1,11 @@
+
 import React, { useEffect, useRef, useState } from 'react';
 import { GameResults, GameConfig, LeaderboardEntry } from './types';
 import applauseSoundFile from './audio/applause.mp3';
 import { launchConfetti } from './utils/confetti';
 import { recordDailyCompletion, StreakInfo } from './DailyChallenge';
 import beeImg from './img/avatars/bee.svg';
+import html2canvas from 'html2canvas';
 
 interface ResultsScreenProps {
   results: GameResults;
@@ -19,6 +21,7 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
   const [isBestScore, setIsBestScore] = useState(false);
   const [streakInfo, setStreakInfo] = useState<StreakInfo | null>(null);
   const [bonus, setBonus] = useState(0);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (config.dailyChallenge) {
@@ -87,6 +90,29 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
     anchor.click();
   };
 
+  const handleShare = async () => {
+    const element = document.querySelector('.scorecard') as HTMLElement | null;
+    if (!element) return;
+    const canvas = await html2canvas(element);
+    const url = canvas.toDataURL('image/png');
+    setShareUrl(url);
+  };
+
+  const handleCopyLink = async () => {
+    if (shareUrl) {
+      await navigator.clipboard.writeText(shareUrl);
+    }
+  };
+
+  const handleDownloadImage = () => {
+    if (shareUrl) {
+      const link = document.createElement('a');
+      link.href = shareUrl;
+      link.download = 'scoreboard.png';
+      link.click();
+    }
+  };
+
   const getWinnerMessage = () => {
     const { winner, participants } = results;
     if (winner) {
@@ -150,6 +176,9 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
       )}
 
       <div className="flex gap-6 mt-12 flex-wrap justify-center">
+        <button onClick={handleShare} className="bg-pink-500 hover:bg-pink-600 px-8 py-5 rounded-xl text-2xl font-bold">
+            📣 Share Score
+        </button>
         <button onClick={handleExport} className="bg-green-500 hover:bg-green-600 px-8 py-5 rounded-xl text-2xl font-bold">
             📤 Export Results
         </button>
@@ -160,6 +189,17 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
             🔄 Play Again
         </button>
       </div>
+
+      {shareUrl && (
+        <div className="flex gap-6 mt-6 flex-wrap justify-center">
+          <button onClick={handleCopyLink} className="bg-yellow-500 hover:bg-yellow-600 px-6 py-4 rounded-xl text-xl font-bold">
+            📋 Copy Link
+          </button>
+          <button onClick={handleDownloadImage} className="bg-teal-500 hover:bg-teal-600 px-6 py-4 rounded-xl text-xl font-bold">
+            💾 Download Image
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GameConfig, Word } from './types';
 import { parseWordList } from './utils/parseWordList';
+import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
+import trophyImg from './img/avatars/trophy.svg';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -19,6 +21,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
 
   const [gameMode, setGameMode] = useState<'team' | 'individual'>('team');
   const [startingLives, setStartingLives] = useState(10);
+  const [bestClassScore] = useState(() => Number(localStorage.getItem('bestClassScore') || '0'));
 
   const getDefaultTeams = (): Participant[] => [
     { name: 'Team Alpha', lives: startingLives, difficultyLevel: 0, points: 0, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0, avatar: getRandomAvatar() },
@@ -564,11 +567,14 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         )}
 
         {error && <p className="text-red-300 text-center mb-4">{error}</p>}
-        
+
         <div className="flex flex-col md:flex-row gap-4 mt-8">
             <button onClick={() => handleStart(false)} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Custom Game</button>
             <button onClick={() => handleStart(true)} className="w-full bg-orange-500 hover:bg-orange-600 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Session Challenge</button>
         </div>
+        {bestClassScore > 0 && (
+          <div className="mt-4 text-center text-yellow-300 text-xl">🏅 Best Class Score: {bestClassScore}</div>
+        )}
         <div className="mt-4 text-center">
             <button onClick={onViewAchievements} className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View Achievements</button>
         </div>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://squidgyg.github.io/spelling-bee-game/",
   "dependencies": {
     "canvas-confetti": "^1.9.3",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.460.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Summary
- enable score sharing from results screen via html2canvas
- allow copying a shareable link or downloading the scoreboard image
- surface best class score on setup screen for bragging rights

## Testing
- `npm test`
- `npm install html2canvas@1.4.1` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b27ae9ec0883329755cdf1eff6067e