### PR TITLE
Add power-up system with inventory and shop

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -23,6 +23,7 @@ import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
 import { audioManager } from "./utils/audio";
+import { powerUps, PowerUp } from "./constants/powerups";
 
 interface GameScreenProps {
   config: GameConfig;
@@ -44,6 +45,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       correct: 0,
       wordsAttempted: 0,
       wordsCorrect: 0,
+      powerUps: p.powerUps || {},
     })),
   );
   const [currentParticipantIndex, setCurrentParticipantIndex] =
@@ -87,6 +89,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
   const [startTime] = React.useState(Date.now());
   const [currentAvatar, setCurrentAvatar] = React.useState("");
+  const [hintPowerUpTrigger, setHintPowerUpTrigger] = React.useState(0);
 
   const playCorrect = useSound(correctSoundFile, config.soundEnabled);
   const playWrong = useSound(wrongSoundFile, config.soundEnabled);
@@ -233,6 +236,36 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       }),
     );
     playShop();
+  };
+
+  const applyPowerUpEffect = (id: string) => {
+    if (id === "freeze-timer") {
+      pauseTimer();
+      setTimeout(() => resumeTimer(), 5000);
+    } else if (id === "extra-hint") {
+      setHintPowerUpTrigger((t) => t + 1);
+    }
+  };
+
+  const handlePowerUp = (pu: PowerUp) => {
+    const participant = participants[currentParticipantIndex];
+    const count = participant.powerUps?.[pu.id] || 0;
+    if (count > 0) {
+      setParticipants((prev) =>
+        prev.map((p, idx) =>
+          idx === currentParticipantIndex
+            ? {
+                ...p,
+                powerUps: { ...p.powerUps, [pu.id]: count - 1 },
+              }
+            : p,
+        ),
+      );
+      applyPowerUpEffect(pu.id);
+    } else if (participant.points >= pu.cost) {
+      spendPoints(currentParticipantIndex, pu.cost);
+      applyPowerUpEffect(pu.id);
+    }
   };
 
   const typeLetter = (letter: string) => {
@@ -553,7 +586,28 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
             showWord={showWord}
             onHintUsed={() => setUsedHint(true)}
             onExtraAttempt={() => setExtraAttempt(true)}
+            powerUpHintTrigger={hintPowerUpTrigger}
           />
+          <div className="flex gap-4 justify-center mb-4">
+            {powerUps.map((pu) => {
+              const count =
+                participants[currentParticipantIndex].powerUps?.[pu.id] || 0;
+              const canAfford =
+                count > 0 ||
+                participants[currentParticipantIndex].points >= pu.cost;
+              return (
+                <button
+                  key={pu.id}
+                  onClick={() => handlePowerUp(pu)}
+                  disabled={!canAfford}
+                  className="bg-blue-500 hover:bg-blue-600 disabled:opacity-50 px-4 py-2 rounded-lg"
+                >
+                  {pu.name}
+                  {count > 0 ? ` x${count}` : ` (-${pu.cost})`}
+                </button>
+              );
+            })}
+          </div>
           <div className="flex gap-2 justify-center mb-4">
             {letters.map((letter, idx) => (
               <div

--- a/ShopScreen.tsx
+++ b/ShopScreen.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { avatars } from './constants/avatars';
+import { powerUps } from './constants/powerups';
+import { Participant } from './types';
+
+interface ShopScreenProps {
+  participant: Participant;
+  onPurchaseAvatar: (avatar: string, cost: number) => void;
+  onPurchasePowerUp: (id: string, cost: number) => void;
+  onBack: () => void;
+}
+
+const ShopScreen: React.FC<ShopScreenProps> = ({
+  participant,
+  onPurchaseAvatar,
+  onPurchasePowerUp,
+  onBack,
+}) => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-600 to-purple-800 p-8 text-white">
+      <h1 className="text-4xl font-bold mb-6">Shop</h1>
+      <p className="mb-6">Coins: {participant.points}</p>
+      <div className="mb-8">
+        <h2 className="text-3xl mb-4">Avatars</h2>
+        <div className="flex gap-4">
+          {Object.entries(avatars).map(([key, avatar]) => (
+            <button
+              key={key}
+              onClick={() => onPurchaseAvatar(key, 10)}
+              className="bg-yellow-300 text-black px-4 py-2 rounded-lg"
+            >
+              <img src={avatar} alt={key} className="w-16 h-16" />
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="mb-8">
+        <h2 className="text-3xl mb-4">Power Ups</h2>
+        <div className="flex gap-4">
+          {powerUps.map(pu => (
+            <button
+              key={pu.id}
+              onClick={() => onPurchasePowerUp(pu.id, pu.cost)}
+              className="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded-lg"
+            >
+              {pu.name} (-{pu.cost})
+            </button>
+          ))}
+        </div>
+      </div>
+      <button onClick={onBack} className="bg-gray-600 px-4 py-2 rounded-lg">
+        Back
+      </button>
+    </div>
+  );
+};
+
+export default ShopScreen;

--- a/components/HintPanel.tsx
+++ b/components/HintPanel.tsx
@@ -11,6 +11,7 @@ interface HintPanelProps {
   showWord: boolean;
   onHintUsed: () => void;
   onExtraAttempt: () => void;
+  powerUpHintTrigger?: number;
 }
 
 const HintPanel: React.FC<HintPanelProps> = ({
@@ -22,6 +23,7 @@ const HintPanel: React.FC<HintPanelProps> = ({
   showWord,
   onHintUsed,
   onExtraAttempt,
+  powerUpHintTrigger = 0,
 }) => {
   const [showHint, setShowHint] = useState(false);
   const [showDefinition, setShowDefinition] = useState(false);
@@ -42,6 +44,23 @@ const HintPanel: React.FC<HintPanelProps> = ({
     setShowPrefix(false);
     setShowSuffix(false);
   }, [word]);
+
+  useEffect(() => {
+    if (powerUpHintTrigger > 0) {
+      const unrevealed = revealedLetters
+        .map((r, i) => (!r ? i : null))
+        .filter(i => i !== null) as number[];
+      if (unrevealed.length > 0) {
+        const randomIndex = unrevealed[Math.floor(Math.random() * unrevealed.length)];
+        setRevealedLetters(prev => {
+          const updated = [...prev];
+          updated[randomIndex] = true;
+          return updated;
+        });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [powerUpHintTrigger]);
 
   useEffect(() => {
     if (!showWord) {

--- a/constants/powerups.ts
+++ b/constants/powerups.ts
@@ -1,0 +1,21 @@
+export interface PowerUp {
+  id: string;
+  name: string;
+  description: string;
+  cost: number;
+}
+
+export const powerUps: PowerUp[] = [
+  {
+    id: 'extra-hint',
+    name: 'Extra Hint',
+    description: 'Reveal a random letter in the current word',
+    cost: 5,
+  },
+  {
+    id: 'freeze-timer',
+    name: 'Freeze Timer',
+    description: 'Pause the timer for five seconds',
+    cost: 8,
+  },
+];

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,7 @@ export interface Participant {
   wordsCorrect: number;
   accuracy?: number;
   avatar?: string;
+  powerUps?: Record<string, number>;
 }
 
 export interface WordDatabase {


### PR DESCRIPTION
## Summary
- Define power-up catalog with Extra Hint and Freeze Timer
- Add inventory bar to GameScreen with timer and hint integration
- Introduce basic Shop screen that sells avatars and power-ups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27aeba9608332bead5cded1797963