### PR TITLE
Add animated background themes

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { GameConfig, Word } from './types';
 import { parseWordList } from './utils/parseWordList';
 import bookImg from './img/avatars/book.svg';
+import type { OptionsState } from './components/GameOptions';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -80,8 +81,14 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const [selectedVoice, setSelectedVoice] = useState<string>(() => localStorage.getItem('selectedVoice') ?? '');
 
-  const applyTheme = (t: string) => {
-    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
+  const applyTheme = (t: OptionsState['theme']) => {
+    document.body.classList.remove(
+      'theme-light',
+      'theme-dark',
+      'theme-honeycomb',
+      'theme-honeycomb-animated',
+      'theme-gradient'
+    );
     document.body.classList.add(`theme-${t}`);
   };
 
@@ -167,7 +174,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     progressionSpeed: 1,
     soundEnabled: localStorage.getItem('soundEnabled') !== 'false',
     effectsEnabled: true,
-    theme: localStorage.getItem('theme') ?? 'light',
+    theme: (localStorage.getItem('theme') as OptionsState['theme']) ?? 'light',
     teacherMode: localStorage.getItem('teacherMode') === 'true',
     musicStyle: localStorage.getItem('musicStyle') ?? 'Funk',
     musicVolume: parseFloat(localStorage.getItem('musicVolume') ?? '1'),
@@ -485,10 +492,21 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>
-                <select value={theme} onChange={e => { const t = e.target.value; setTheme(t); localStorage.setItem('theme', t); applyTheme(t); }} className="p-2 rounded-md bg-white/20 text-white">
+                <select
+                    value={theme}
+                    onChange={e => {
+                        const t = e.target.value as OptionsState['theme'];
+                        setTheme(t);
+                        localStorage.setItem('theme', t);
+                        applyTheme(t);
+                    }}
+                    className="p-2 rounded-md bg-white/20 text-white"
+                >
                     <option value="light">Light</option>
                     <option value="dark">Dark</option>
                     <option value="honeycomb">Honeycomb</option>
+                    <option value="honeycomb-animated">Animated Honeycomb</option>
+                    <option value="gradient">Animated Gradient</option>
                 </select>
             </div>
             <div className="bg-white/10 p-6 rounded-lg">

--- a/components/GameOptions.tsx
+++ b/components/GameOptions.tsx
@@ -7,7 +7,7 @@ export interface OptionsState {
   progressionSpeed: number;
   soundEnabled: boolean;
   effectsEnabled: boolean;
-  theme: string;
+  theme: 'light' | 'dark' | 'honeycomb' | 'honeycomb-animated' | 'gradient';
   teacherMode: boolean;
   musicStyle: string;
   musicVolume: number;
@@ -19,8 +19,14 @@ interface GameOptionsProps {
 }
 
 const GameOptions: React.FC<GameOptionsProps> = ({ options, setOptions }) => {
-  const applyTheme = (t: string) => {
-    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
+  const applyTheme = (t: OptionsState['theme']) => {
+    document.body.classList.remove(
+      'theme-light',
+      'theme-dark',
+      'theme-honeycomb',
+      'theme-honeycomb-animated',
+      'theme-gradient'
+    );
     document.body.classList.add(`theme-${t}`);
   };
 
@@ -133,12 +139,16 @@ const GameOptions: React.FC<GameOptionsProps> = ({ options, setOptions }) => {
         <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>
         <select
           value={options.theme}
-          onChange={e => setOptions(o => ({ ...o, theme: e.target.value }))}
+          onChange={e =>
+            setOptions(o => ({ ...o, theme: e.target.value as OptionsState['theme'] }))
+          }
           className="p-2 rounded-md bg-white/20 text-white"
         >
           <option value="light">Light</option>
           <option value="dark">Dark</option>
           <option value="honeycomb">Honeycomb</option>
+          <option value="honeycomb-animated">Animated Honeycomb</option>
+          <option value="gradient">Animated Gradient</option>
         </select>
       </div>
 

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -6,6 +6,7 @@ import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
 import useMusic from './utils/useMusic';
+import type { OptionsState } from './components/GameOptions';
 
 // --- Main App Component ---
 const SpellingBeeGame = () => {
@@ -79,9 +80,15 @@ const SpellingBeeGame = () => {
     };
 
     useEffect(() => {
-        const savedTheme = localStorage.getItem('theme');
+        const savedTheme = localStorage.getItem('theme') as OptionsState['theme'] | null;
         if (savedTheme) {
-            document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
+            document.body.classList.remove(
+                'theme-light',
+                'theme-dark',
+                'theme-honeycomb',
+                'theme-honeycomb-animated',
+                'theme-gradient'
+            );
             document.body.classList.add(`theme-${savedTheme}`);
         }
     }, []);

--- a/style.css
+++ b/style.css
@@ -44,6 +44,42 @@ body.theme-honeycomb {
     color: #78350f;
 }
 
+@keyframes honeycomb-shift {
+    from {
+        background-position: 0 0;
+    }
+    to {
+        background-position: 20px 20px;
+    }
+}
+
+@keyframes gradient-move {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+body.theme-honeycomb-animated {
+    background-color: #fef7cd;
+    background-image: radial-gradient(#fbbf24 1px, transparent 1px);
+    background-size: 20px 20px;
+    animation: honeycomb-shift 10s linear infinite;
+    color: #78350f;
+}
+
+body.theme-gradient {
+    background: linear-gradient(45deg, #fde68a, #fbbf24, #f59e0b, #fcd34d);
+    background-size: 400% 400%;
+    animation: gradient-move 15s ease infinite;
+    color: #1f2937;
+}
+
 /* Teacher Mode increases overall scaling for easier classroom viewing */
 body.teacher-mode {
     font-size: 1.25rem;
@@ -324,7 +360,7 @@ video {
 
 /* Print styles */
 @media print {
-    .no-print {
-        display: none;
-    }
+.no-print {
+    display: none;
+}
 }


### PR DESCRIPTION
## Summary
- Add honeycomb and gradient background animations
- Allow selection of animated backgrounds in settings
- Apply saved background theme across entire app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27aec6e648332a8ee06a54e92114f