### PR TITLE
feat: add music playlist selector and chill mode timer

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SkipForward } from "lucide-react";
+import { SkipForward, Music } from "lucide-react";
 import {
   GameConfig,
   Word,
@@ -22,11 +22,21 @@ import useWordSelection, { difficultyOrder } from "./utils/useWordSelection";
 import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
+import { AudioSettings } from "./components/AudioSettings";
 import { audioManager } from "./utils/audio";
 
 interface GameScreenProps {
   config: GameConfig;
   onEndGame: (results: GameResults) => void;
+  musicStyle: string;
+  onMusicStyleChange: (style: string) => void;
+  musicVolume?: number;
+  onMusicVolumeChange?: (volume: number) => void;
+  soundEnabled?: boolean;
+  onSoundEnabledChange?: (enabled: boolean) => void;
+  isMusicPlaying?: boolean;
+  onToggleMusicPlaying?: () => void;
+  onQuit?: () => void;
 }
 
 interface Feedback {
@@ -36,7 +46,12 @@ interface Feedback {
 
 // difficultyOrder is imported from useWordSelection
 
-const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
+const GameScreen: React.FC<GameScreenProps> = ({
+  config,
+  onEndGame,
+  musicStyle,
+  onMusicStyleChange,
+}) => {
   const [participants, setParticipants] = React.useState<Participant[]>(
     config.participants.map((p) => ({
       ...p,
@@ -87,6 +102,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
   const [startTime] = React.useState(Date.now());
   const [currentAvatar, setCurrentAvatar] = React.useState("");
+  const [showAudioSettings, setShowAudioSettings] = React.useState(false);
+
+  const handleTrackChange = (style: string) => {
+    onMusicStyleChange(style);
+  };
 
   const playCorrect = useSound(correctSoundFile, config.soundEnabled);
   const playWrong = useSound(wrongSoundFile, config.soundEnabled);
@@ -111,6 +131,13 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     playTimeout();
     handleIncorrectAttempt();
   });
+
+  const timerClass =
+    timeLeft <= 10
+      ? config.chillMode
+        ? "timer-warning-chill"
+        : "timer-warning"
+      : "timer-normal";
   React.useEffect(() => {
     if (localStorage.getItem("teacherMode") === "true") {
       document.body.classList.add("teacher-mode");
@@ -480,18 +507,23 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       )}
 
       <div className="absolute top-8 right-8 text-center z-50">
-        <div
-          className={`text-6xl font-bold ${timeLeft <= 10 ? "text-red-500" : "text-yellow-300"}`}
-        >
-          {timeLeft}
-        </div>
+        <div className={`text-6xl font-bold ${timerClass}`}>{timeLeft}</div>
         <div className="text-lg">seconds left</div>
-        <button
-          onClick={isPaused ? resumeTimer : pauseTimer}
-          className="mt-2 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
-        >
-          {isPaused ? "Resume" : "Pause"}
-        </button>
+        <div className="flex justify-center space-x-2 mt-2">
+          <button
+            onClick={isPaused ? resumeTimer : pauseTimer}
+            className="bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+          >
+            {isPaused ? "Resume" : "Pause"}
+          </button>
+          <button
+            onClick={() => setShowAudioSettings((s) => !s)}
+            className="bg-yellow-300 text-black p-2 rounded-lg"
+            aria-label="Music settings"
+          >
+            <Music className="w-5 h-5" />
+          </button>
+        </div>
       </div>
 
       <audio-controls className="audio-controls">
@@ -591,6 +623,17 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       {isPaused && (
         <div className="absolute inset-0 bg-black/50 flex items-center justify-center text-6xl font-bold z-40">
           Paused
+        </div>
+      )}
+
+      {showAudioSettings && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-lg w-80">
+            <AudioSettings
+              currentTrack={musicStyle}
+              onTrackChange={handleTrackChange}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/audio/playlist.js
+++ b/audio/playlist.js
@@ -1,0 +1,5 @@
+export const PLAYLIST = [
+  { style: 'Funk', label: 'Funk' },
+  { style: 'Rock', label: 'Rock' },
+  { style: 'Tech House', label: 'Tech House' }
+];

--- a/components/AudioSettings.jsx
+++ b/components/AudioSettings.jsx
@@ -1,12 +1,27 @@
 // components/AudioSettings.jsx
 import React from 'react';
 import { audioManager } from '../utils/audio';
+import { PLAYLIST } from '../audio/playlist';
 
-export function AudioSettings() {
+export function AudioSettings({ currentTrack, onTrackChange }) {
   const [musicVolume, setMusicVolume] = React.useState(audioManager.volume.music * 100);
   const [sfxVolume, setSfxVolume] = React.useState(audioManager.volume.sfx * 100);
   const [isMusicMuted, setIsMusicMuted] = React.useState(audioManager.isMusicMuted);
   const [areSoundsMuted, setAreSoundsMuted] = React.useState(audioManager.areSoundsMuted);
+  const [track, setTrack] = React.useState(
+    currentTrack || localStorage.getItem('musicStyle') || PLAYLIST[0].style,
+  );
+
+  React.useEffect(() => {
+    if (currentTrack) setTrack(currentTrack);
+  }, [currentTrack]);
+
+  const handleTrackChange = (e) => {
+    const style = e.target.value;
+    setTrack(style);
+    localStorage.setItem('musicStyle', style);
+    if (onTrackChange) onTrackChange(style);
+  };
 
   const handleMusicVolumeChange = (e) => {
     const volume = parseInt(e.target.value) / 100;
@@ -37,6 +52,21 @@ export function AudioSettings() {
       </div>
 
       <div className="space-y-4">
+        <div className="bg-white bg-opacity-80 rounded-lg p-4 shadow-md">
+          <label className="text-sm font-semibold text-gray-700">Playlist</label>
+          <select
+            value={track}
+            onChange={handleTrackChange}
+            className="mt-2 w-full p-2 border rounded"
+          >
+            {PLAYLIST.map((t) => (
+              <option key={t.style} value={t.style}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <div className="bg-white bg-opacity-80 rounded-lg p-4 shadow-md">
           <div className="flex items-center justify-between mb-3">
             <label className="text-sm font-semibold text-gray-700">Music Volume</label>

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -14,10 +14,18 @@ const SpellingBeeGame = () => {
     const [gameResults, setGameResults] = useState(null);
     const [customWords, setCustomWords] = useState({ easy: [], medium: [], tricky: [] });
     const [wordDatabase, setWordDatabase] = useState({ easy: [], medium: [], tricky: [] });
-    const [musicStyle, setMusicStyle] = useState('Funk');
-    const [musicVolume, setMusicVolume] = useState(0.5);
+    const [musicStyle, setMusicStyle] = useState(() => localStorage.getItem('musicStyle') || 'Funk');
+    const [musicVolume, setMusicVolume] = useState(() => parseFloat(localStorage.getItem('musicVolume') ?? '0.5'));
     const [soundEnabled, setSoundEnabled] = useState(true);
     const [isMusicPlaying, setIsMusicPlaying] = useState(true);
+
+    useEffect(() => {
+        localStorage.setItem('musicStyle', musicStyle);
+    }, [musicStyle]);
+
+    useEffect(() => {
+        localStorage.setItem('musicVolume', String(musicVolume));
+    }, [musicVolume]);
 
     useEffect(() => {
         fetch('words.json')

--- a/style.css
+++ b/style.css
@@ -155,8 +155,13 @@ video {
     animation: pulse 1s infinite;
 }
 
+.timer-warning-chill {
+    color: #ef4444;
+    animation: pulse 3s infinite;
+}
+
 .timer-normal {
-    color: white;
+    color: #facc15;
 }
 
 /* Word reveal animation */

--- a/types.ts
+++ b/types.ts
@@ -43,6 +43,7 @@ export interface GameConfig {
   musicVolume: number;
   difficultyLevel: number;
   progressionSpeed: number;
+  chillMode?: boolean;
   /** When true, the game uses the daily challenge word list */
   dailyChallenge?: boolean;
 }


### PR DESCRIPTION
## Summary
- add small audio playlist and expose track selector in audio settings
- add in-game music button to open audio settings
- slow timer flash when chill mode enabled and persist music choice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27aede64883328ef341f7969376e0