### PR TITLE
Add phonics breakdown component with phoneme audio

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -22,6 +22,7 @@ import useWordSelection, { difficultyOrder } from "./utils/useWordSelection";
 import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
+import PhonicsBreakdown from "./components/PhonicsBreakdown";
 import { audioManager } from "./utils/audio";
 
 interface GameScreenProps {
@@ -87,6 +88,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
   const [startTime] = React.useState(Date.now());
   const [currentAvatar, setCurrentAvatar] = React.useState("");
+  const [showPhonics, setShowPhonics] = React.useState(false);
 
   const playCorrect = useSound(correctSoundFile, config.soundEnabled);
   const playWrong = useSound(wrongSoundFile, config.soundEnabled);
@@ -151,7 +153,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
       if (hiddenInputRef.current) {
         hiddenInputRef.current.focus();
       }
+      setShowPhonics(false);
       speak(nextWord.word);
+      setShowPhonics(true);
       startTimer();
     } else {
       onEndGameWithMissedWords();
@@ -532,7 +536,10 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
               </div>
             )}
             <button
-              onClick={() => speak(currentWord.word)}
+              onClick={() => {
+                speak(currentWord.word);
+                setShowPhonics(true);
+              }}
               className="absolute top-0 left-0 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
             >
               Replay Word
@@ -542,6 +549,12 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
               className="absolute top-0 right-0 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
             >
               {showWord ? "Hide Word" : "Show Word"}
+            </button>
+            <button
+              onClick={() => setShowPhonics(true)}
+              className="absolute top-0 left-1/2 -translate-x-1/2 bg-yellow-300 text-black px-4 py-2 rounded-lg font-bold"
+            >
+              Hint
             </button>
           </div>
           <HintPanel
@@ -554,6 +567,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
             onHintUsed={() => setUsedHint(true)}
             onExtraAttempt={() => setExtraAttempt(true)}
           />
+          {showPhonics && <PhonicsBreakdown word={currentWord} />}
           <div className="flex gap-2 justify-center mb-4">
             {letters.map((letter, idx) => (
               <div

--- a/components/PhonicsBreakdown.tsx
+++ b/components/PhonicsBreakdown.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Word } from '../types';
+import { speak } from '../utils/tts';
+
+interface PhonicsBreakdownProps {
+  word: Word;
+}
+
+const PhonicsBreakdown: React.FC<PhonicsBreakdownProps> = ({ word }) => {
+  if (!word.phonemes || word.phonemes.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap justify-center mb-4">
+      {word.phonemes.map((p, idx) => (
+        <button
+          key={idx}
+          onClick={() => speak(p)}
+          className="m-1 px-2 py-1 bg-yellow-300 text-black rounded"
+        >
+          {p}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default PhonicsBreakdown;

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,7 @@
 export interface Word {
   word: string;
   syllables: string[];
+  phonemes: string[];
   definition: string;
   origin: string;
   example: string;

--- a/words.json
+++ b/words.json
@@ -3,6 +3,7 @@
     {
       "word": "friend",
       "syllables": ["friend"],
+      "phonemes": ["f", "r", "eh", "n", "d"],
       "definition": "A person you like and know well",
       "origin": "Old English 'freond', from Germanic root meaning 'to love'",
       "example": "My best friend and I love to play together.",
@@ -13,6 +14,7 @@
     {
       "word": "happy",
       "syllables": ["hap", "py"],
+      "phonemes": ["h", "a", "p", "ee"],
       "definition": "Feeling or showing pleasure and contentment",
       "origin": "Middle English 'happy', from 'hap' meaning luck or fortune",
       "example": "The children were happy to see the circus.",
@@ -25,6 +27,7 @@
     {
       "word": "necessary",
       "syllables": ["nec", "es", "sar", "y"],
+      "phonemes": ["n", "e", "s", "uh", "s", "eh", "r", "ee"],
       "definition": "Required to be done or achieved; essential",
       "origin": "Latin 'necessarius', from 'necesse' meaning unavoidable",
       "example": "It is necessary to study hard for the test.",
@@ -37,6 +40,7 @@
     {
       "word": "chrysanthemum",
       "syllables": ["chry", "san", "the", "mum"],
+      "phonemes": ["k", "r", "i", "s", "an", "th", "uh", "m", "uh", "m"],
       "definition": "A type of flower with many thin petals",
       "origin": "Greek 'chrysos' (gold) + 'anthemon' (flower)",
       "example": "The chrysanthemum bloomed beautifully in autumn.",


### PR DESCRIPTION
Implemented fresh on `main` in commit `3e60b7b`.

The component and some phoneme data already existed, but the current app was not preserving or displaying phonics data. This version adds:

- Keeps phoneme data when loading words
- Provides a fallback phonics breakdown from word letters when explicit phonemes are missing
- Adds a gameplay `Show Phonics` toggle when phonics data is available
- Updates `PhonicsBreakdown` to use simple speakable phoneme buttons instead of missing static audio files
- Adds Playwright coverage for showing the phonics panel

Verified with local build, unit tests, Chromium e2e, CI, GitHub Pages deploy, and live Pages e2e.