### PR TITLE
Add morphology card and data for word parts

### DIFF
--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -4,6 +4,7 @@ import applauseSoundFile from './audio/applause.mp3';
 import { launchConfetti } from './utils/confetti';
 import { recordDailyCompletion, StreakInfo } from './DailyChallenge';
 import beeImg from './img/avatars/bee.svg';
+import MorphologyCard from './components/MorphologyCard';
 
 interface ResultsScreenProps {
   results: GameResults;
@@ -144,6 +145,9 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
           {results.missedWords.map((w, index) => (
             <div key={index} className="text-left text-xl mb-2">
               <span className="font-bold">{w.word}</span> - {w.definition}
+              {(w.prefix || w.suffix) && (
+                <MorphologyCard word={w} database={config.wordDatabase} />
+              )}
             </div>
           ))}
         </div>

--- a/components/MorphologyCard.tsx
+++ b/components/MorphologyCard.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import { Word, WordDatabase } from '../types';
+
+interface MorphologyCardProps {
+  word: Word;
+  database: WordDatabase;
+}
+
+const MorphologyCard: React.FC<MorphologyCardProps> = ({ word, database }) => {
+  const allWords = useMemo(() =>
+    Object.values(database).flat(),
+  [database]);
+
+  const prefixExamples = useMemo(() => {
+    if (!word.prefix) return [] as string[];
+    return allWords
+      .filter(w => w.word !== word.word && w.prefix === word.prefix)
+      .map(w => w.word)
+      .slice(0, 3);
+  }, [allWords, word]);
+
+  const suffixExamples = useMemo(() => {
+    if (!word.suffix) return [] as string[];
+    return allWords
+      .filter(w => w.word !== word.word && w.suffix === word.suffix)
+      .map(w => w.word)
+      .slice(0, 3);
+  }, [allWords, word]);
+
+  if (!word.prefix && !word.suffix) return null;
+
+  return (
+    <div className="bg-white/10 p-3 rounded-md mt-2 text-sm">
+      {word.prefix && (
+        <div className="mb-2">
+          <div className="font-bold">Prefix: {word.prefix}</div>
+          {word.prefixMeaning && (
+            <div className="text-gray-200">{word.prefixMeaning}</div>
+          )}
+          {prefixExamples.length > 0 && (
+            <div className="text-gray-300">
+              Example words: {prefixExamples.join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+      {word.suffix && (
+        <div>
+          <div className="font-bold">Suffix: {word.suffix}</div>
+          {word.suffixMeaning && (
+            <div className="text-gray-200">{word.suffixMeaning}</div>
+          )}
+          {suffixExamples.length > 0 && (
+            <div className="text-gray-300">
+              Example words: {suffixExamples.join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MorphologyCard;

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,8 @@ export interface Word {
   example: string;
   prefix?: string;
   suffix?: string;
+  prefixMeaning?: string;
+  suffixMeaning?: string;
   pronunciation?: string;
 }
 

--- a/words.json
+++ b/words.json
@@ -8,6 +8,8 @@
       "example": "My best friend and I love to play together.",
       "prefix": "",
       "suffix": "",
+      "prefixMeaning": "",
+      "suffixMeaning": "",
       "pronunciation": "FREND"
     },
     {
@@ -18,6 +20,8 @@
       "example": "The children were happy to see the circus.",
       "prefix": "hap",
       "suffix": "py",
+      "prefixMeaning": "luck, fortune",
+      "suffixMeaning": "characterized by",
       "pronunciation": "HAP-ee"
     }
   ],
@@ -30,6 +34,8 @@
       "example": "It is necessary to study hard for the test.",
       "prefix": "necess",
       "suffix": "ary",
+      "prefixMeaning": "unavoidable",
+      "suffixMeaning": "related to",
       "pronunciation": "NES-uh-ser-ee"
     }
   ],
@@ -42,6 +48,8 @@
       "example": "The chrysanthemum bloomed beautifully in autumn.",
       "prefix": "chryso",
       "suffix": "anthemum",
+      "prefixMeaning": "gold",
+      "suffixMeaning": "flower",
       "pronunciation": "kri-SAN-thuh-mum"
     }
   ]


### PR DESCRIPTION
## Summary
- extend `Word` type with prefix/suffix meanings and update default word list
- add `MorphologyCard` to show meanings and example words for prefixes/suffixes
- display morphology details for missed words on the results screen

## Testing
- `npm test`
- `npm run build` *(fails: The symbol "teams" has already been declared in SetupScreen.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b27b8c5f6883329e931fa1acb9338b