### PR TITLE
feat: add review queue and practice mode

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -23,6 +23,7 @@ import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
 import { audioManager } from "./utils/audio";
+import { addReviewWord } from "./utils/reviewQueue";
 
 interface GameScreenProps {
   config: GameConfig;
@@ -177,7 +178,10 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
     }
 
     setFeedback({ message: "Incorrect. Try again next time!", type: "error" });
-    if (currentWord) setMissedWords((prev) => [...prev, currentWord]);
+    if (currentWord) {
+      setMissedWords((prev) => [...prev, currentWord]);
+      addReviewWord(currentWord.word);
+    }
 
     const updatedParticipants = participants.map((p, index) => {
       if (index === currentParticipantIndex) {
@@ -385,6 +389,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
         ...prev,
         review: [...prev.review, currentWord],
       }));
+      addReviewWord(currentWord.word);
     }
     setAttemptedParticipants(new Set());
 

--- a/PracticeScreen.tsx
+++ b/PracticeScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { getDueReviewWords, rescheduleReviewWord } from './utils/reviewQueue';
+
+interface PracticeScreenProps {
+  onBack: () => void;
+}
+
+const PracticeScreen: React.FC<PracticeScreenProps> = ({ onBack }) => {
+  const [queue, setQueue] = React.useState(() => getDueReviewWords());
+  const current = queue[0];
+
+  const handleResult = (success: boolean) => {
+    if (!current) return;
+    rescheduleReviewWord(current.word, success);
+    const updated = getDueReviewWords();
+    setQueue(updated);
+  };
+
+  if (!current) {
+    return (
+      <div className='min-h-screen flex flex-col items-center justify-center gap-4 bg-gradient-to-br from-indigo-600 to-purple-800 text-white'>
+        <p className='text-2xl'>No review words due!</p>
+        <button className='px-4 py-2 bg-yellow-500 rounded' onClick={onBack}>Back</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center gap-4 bg-gradient-to-br from-indigo-600 to-purple-800 text-white'>
+      <h2 className='text-3xl mb-4'>Practice Word</h2>
+      <div className='text-4xl font-bold'>{current.word}</div>
+      <div className='flex gap-4 mt-6'>
+        <button className='px-4 py-2 bg-green-600 rounded' onClick={() => handleResult(true)}>Got it</button>
+        <button className='px-4 py-2 bg-red-600 rounded' onClick={() => handleResult(false)}>Missed</button>
+      </div>
+      <button className='mt-6 underline' onClick={onBack}>Quit</button>
+    </div>
+  );
+};
+
+export default PracticeScreen;

--- a/utils/reviewQueue.ts
+++ b/utils/reviewQueue.ts
@@ -1,0 +1,68 @@
+const STORAGE_KEY = 'reviewQueue';
+const DAY = 24 * 60 * 60 * 1000;
+
+interface ReviewItem {
+  word: string;
+  nextReview: number;
+  interval: number;
+  successCount: number;
+}
+
+function loadQueue(): ReviewItem[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function saveQueue(queue: ReviewItem[]) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+}
+
+export function addReviewWord(word: string) {
+  if (!word) return;
+  const queue = loadQueue();
+  const existing = queue.find(q => q.word === word);
+  const now = Date.now();
+  if (existing) {
+    existing.nextReview = now + DAY;
+    existing.interval = DAY;
+    existing.successCount = 0;
+  } else {
+    queue.push({ word, nextReview: now + DAY, interval: DAY, successCount: 0 });
+  }
+  saveQueue(queue);
+}
+
+export function getDueReviewWords(): ReviewItem[] {
+  const now = Date.now();
+  return loadQueue().filter(item => item.nextReview <= now);
+}
+
+export function rescheduleReviewWord(word: string, wasCorrect: boolean) {
+  const queue = loadQueue();
+  const index = queue.findIndex(q => q.word === word);
+  if (index === -1) return;
+  const item = queue[index];
+  const now = Date.now();
+  if (wasCorrect) {
+    item.successCount += 1;
+    item.interval = item.interval * 2;
+    item.nextReview = now + item.interval;
+    if (item.successCount >= 3) {
+      queue.splice(index, 1);
+    }
+  } else {
+    item.successCount = 0;
+    item.interval = DAY;
+    item.nextReview = now + DAY;
+  }
+  saveQueue(queue);
+}
+
+export function dueReviewCount(): number {
+  return getDueReviewWords().length;
+}


### PR DESCRIPTION
Implemented fresh on `main` in commit `51be038`.

The old branch overlapped with the new warm-up mode, so I kept the distinct useful part and integrated it into the current flow:

- Added a persisted missed-word review queue
- Adds skipped/all-missed words to review
- Warm-up mode prioritises due review words before the general word list
- Correct review answers are spaced out and eventually removed
- Added unit coverage for review queue behaviour

Verified with local build, unit tests, Chromium e2e, CI, and GitHub Pages deploy.