### PR TITLE
Add global accessibility settings with font and size controls

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -21,6 +21,7 @@ import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
 import { audioManager } from "./utils/audio";
+import AccessibilitySettings from "./components/AccessibilitySettings";
 
 interface GameScreenProps {
   config: GameConfig;
@@ -60,6 +61,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
   });
   const [extraAttempt, setExtraAttempt] = React.useState(false);
   const [isHelpOpen, setIsHelpOpen] = React.useState(false);
+  const [showAccessibility, setShowAccessibility] = React.useState(false);
   const {
     wordQueues,
     setWordQueues,
@@ -592,9 +594,20 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
         <SkipForward size={24} />
       </button>
 
-      {isPaused && (
-        <div className="absolute inset-0 bg-black/50 flex items-center justify-center text-6xl font-bold z-40">
-          Paused
+      {isPaused && !showAccessibility && (
+        <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center text-6xl font-bold z-40">
+          <div>Paused</div>
+          <button
+            onClick={() => setShowAccessibility(true)}
+            className="mt-8 bg-yellow-300 text-black px-6 py-3 rounded text-2xl"
+          >
+            Accessibility
+          </button>
+        </div>
+      )}
+      {showAccessibility && (
+        <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-50">
+          <AccessibilitySettings onClose={() => setShowAccessibility(false)} />
         </div>
       )}
     </div>

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GameConfig, Word } from './types';
 import { parseWordList } from './utils/parseWordList';
 import bookImg from './img/avatars/book.svg';
+import AccessibilitySettings from './components/AccessibilitySettings';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -19,6 +20,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
 
   const [gameMode, setGameMode] = useState<'team' | 'individual'>('team');
   const [startingLives, setStartingLives] = useState(10);
+  const [showAccessibility, setShowAccessibility] = useState(false);
 
   const getDefaultTeams = (): Participant[] => [
     { name: 'Team Alpha', lives: startingLives, difficultyLevel: 0, points: 0, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0, avatar: getRandomAvatar() },
@@ -365,7 +367,18 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   };
   
   return (
-    <div className="min-h-screen p-8 text-white font-body">
+    <div className="min-h-screen p-8 text-white font-body relative">
+      <button
+        onClick={() => setShowAccessibility(true)}
+        className="absolute top-4 right-4 bg-yellow-300 text-black px-4 py-2 rounded font-bold"
+      >
+        Accessibility
+      </button>
+      {showAccessibility && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <AccessibilitySettings onClose={() => setShowAccessibility(false)} />
+        </div>
+      )}
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
             <div className="flex items-center justify-center gap-3 mb-4">

--- a/components/AccessibilitySettings.tsx
+++ b/components/AccessibilitySettings.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+export function applyAccessibilitySettings(fontOverride?: string, sizeOverride?: number) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  const font = fontOverride || localStorage.getItem('appFont') || 'system-ui';
+  const size = sizeOverride !== undefined ? sizeOverride : parseInt(localStorage.getItem('appFontSize') || '16', 10);
+  root.style.setProperty('--app-font', font);
+  root.style.setProperty('--app-font-size', `${size}px`);
+}
+
+interface AccessibilitySettingsProps {
+  onClose?: () => void;
+}
+
+const AccessibilitySettings: React.FC<AccessibilitySettingsProps> = ({ onClose }) => {
+  const [font, setFont] = React.useState<string>(localStorage.getItem('appFont') || 'system-ui');
+  const [size, setSize] = React.useState<number>(
+    parseInt(localStorage.getItem('appFontSize') || '16', 10)
+  );
+
+  React.useEffect(() => {
+    applyAccessibilitySettings(font, size);
+    localStorage.setItem('appFont', font);
+    localStorage.setItem('appFontSize', String(size));
+  }, [font, size]);
+
+  return (
+    <div className="bg-white rounded-lg p-6 shadow-lg max-w-md w-full text-gray-800">
+      <h3 className="text-xl font-bold mb-4 text-center">Accessibility Settings</h3>
+
+      <div className="mb-4">
+        <label className="block mb-1 font-semibold">Font</label>
+        <select
+          value={font}
+          onChange={(e) => setFont(e.target.value)}
+          className="w-full p-2 border rounded"
+        >
+          <option value="system-ui">Default</option>
+          <option value="'OpenDyslexic', system-ui">OpenDyslexic</option>
+        </select>
+      </div>
+
+      <div className="mb-4">
+        <label className="block mb-1 font-semibold">Font Size: {size}px</label>
+        <input
+          type="range"
+          min={14}
+          max={32}
+          value={size}
+          onChange={(e) => setSize(parseInt(e.target.value))}
+          className="w-full"
+        />
+      </div>
+
+      <div className="text-center">
+        <button
+          onClick={onClose}
+          className="mt-2 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AccessibilitySettings;
+

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -6,6 +6,7 @@ import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
 import useMusic from './utils/useMusic';
+import { applyAccessibilitySettings } from './components/AccessibilitySettings';
 
 // --- Main App Component ---
 const SpellingBeeGame = () => {
@@ -24,6 +25,10 @@ const SpellingBeeGame = () => {
             .then(res => res.json())
             .then(data => setWordDatabase(data))
             .catch(err => console.error('Failed to load word list', err));
+    }, []);
+
+    useEffect(() => {
+        applyAccessibilitySettings();
     }, []);
 
     const handleAddCustomWords = (newWords) => {

--- a/style.css
+++ b/style.css
@@ -1,23 +1,29 @@
 /* Custom styles for Spelling Bee Championship */
 
-<<<<<<< HEAD
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
+@import url('https://fonts.cdnfonts.com/css/open-dyslexic');
 
 :root {
   --primary-color: #2563eb; /* Improved contrast blue */
   --text-color: #1e293b; /* Darker text for better readability */
   --bg-color: #f8fafc; /* Light background */
-  
+
   /* Dark mode variables */
   --dark-primary: #3b82f6;
   --dark-text: #f1f5f9;
   --dark-bg: #0f172a;
+
+  /* Accessibility settings */
+  --app-font: 'Roboto', sans-serif;
+  --app-font-size: 16px;
 }
 
-=======
->>>>>>> origin/codex/import-google-fonts-and-configure-tailwind
 * {
     box-sizing: border-box;
+}
+
+html {
+    font-size: var(--app-font-size);
 }
 
 body {
@@ -27,6 +33,12 @@ body {
     background-image: url('img/bee-honeycomb.svg');
     background-size: 200px 173px;
     background-repeat: repeat;
+    font-family: var(--app-font) !important;
+}
+
+.font-body,
+.font-heading {
+    font-family: var(--app-font) !important;
 }
 
 body.theme-light {


### PR DESCRIPTION
Implemented fresh on `main` in commit `2954681`.

Kept the useful intent from this PR, but avoided merging the stale branch because it had drifted from the current app structure. The shipped version adds:

- A setup-screen Accessibility Settings modal
- A game-screen Accessibility button
- Persisted font, text size, and reduce-motion settings
- Global CSS application through app-level settings
- Browser coverage for changing the settings

Verified with local build/unit/e2e, GitHub Pages deploy, CI, and live Pages e2e.