### PR TITLE
feat: track classroom comfort

### DIFF
--- a/HistoryScreen.tsx
+++ b/HistoryScreen.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+
+interface SessionRecord {
+  date: string;
+  score: number;
+  mood?: string;
+}
+
+interface HistoryScreenProps {
+  onBack: () => void;
+}
+
+const HistoryScreen: React.FC<HistoryScreenProps> = ({ onBack }) => {
+  const [history, setHistory] = useState<SessionRecord[]>([]);
+
+  useEffect(() => {
+    const stored: SessionRecord[] = JSON.parse(localStorage.getItem('sessionHistory') || '[]');
+    setHistory(stored);
+  }, []);
+
+  useEffect(() => {
+    if (localStorage.getItem('teacherMode') === 'true') {
+      document.body.classList.add('teacher-mode');
+    } else {
+      document.body.classList.remove('teacher-mode');
+    }
+  }, []);
+
+  const moodCounts = history.reduce<Record<string, number>>((acc, h) => {
+    if (h.mood) {
+      acc[h.mood] = (acc[h.mood] || 0) + 1;
+    }
+    return acc;
+  }, {});
+  const totalMoodEntries = Object.values(moodCounts).reduce((a, b) => a + b, 0);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white text-center flex flex-col items-center justify-center font-body">
+      <h1 className="text-6xl font-bold mb-8 text-yellow-300 uppercase font-heading">📚 History</h1>
+      <div className="bg-white/10 p-8 rounded-lg w-full max-w-md scorecard">
+        {history.length === 0 ? (
+          <div className="text-xl">No history yet.</div>
+        ) : (
+          <>
+            <div className="text-left text-xl mb-4">
+              <div>Total Sessions: {history.length}</div>
+              {totalMoodEntries > 0 && (
+                <div className="mt-2 space-y-1">
+                  <div>😊 {moodCounts['😊'] || 0} ({Math.round(((moodCounts['😊'] || 0) / totalMoodEntries) * 100)}%)</div>
+                  <div>😐 {moodCounts['😐'] || 0} ({Math.round(((moodCounts['😐'] || 0) / totalMoodEntries) * 100)}%)</div>
+                  <div>😢 {moodCounts['😢'] || 0} ({Math.round(((moodCounts['😢'] || 0) / totalMoodEntries) * 100)}%)</div>
+                </div>
+              )}
+            </div>
+            <ul className="text-xl space-y-2 max-h-64 overflow-y-auto">
+              {history
+                .slice()
+                .reverse()
+                .map((h, idx) => (
+                  <li key={idx} className="flex justify-between">
+                    <span>{new Date(h.date).toLocaleString()}</span>
+                    <span>{h.score} pts {h.mood || ''}</span>
+                  </li>
+                ))}
+            </ul>
+          </>
+        )}
+      </div>
+      <button
+        onClick={onBack}
+        className="mt-8 bg-blue-500 hover:bg-blue-600 px-8 py-4 rounded-xl text-2xl font-bold block mx-auto"
+      >
+        Back
+      </button>
+    </div>
+  );
+};
+
+export default HistoryScreen;

--- a/ResultsScreen.tsx
+++ b/ResultsScreen.tsx
@@ -19,6 +19,7 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
   const [isBestScore, setIsBestScore] = useState(false);
   const [streakInfo, setStreakInfo] = useState<StreakInfo | null>(null);
   const [bonus, setBonus] = useState(0);
+  const [showMoodModal, setShowMoodModal] = useState(true);
 
   useEffect(() => {
     if (config.dailyChallenge) {
@@ -52,10 +53,6 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
   }, [results, config.dailyChallenge, bonus]);
 
   useEffect(() => {
-    const history: { date: string; score: number }[] = JSON.parse(localStorage.getItem('sessionHistory') || '[]');
-    history.push({ date: new Date().toISOString(), score: totalScore });
-    localStorage.setItem('sessionHistory', JSON.stringify(history));
-
     const storedBest = Number(localStorage.getItem('bestClassScore') || '0');
     if (totalScore > storedBest) {
       localStorage.setItem('bestClassScore', String(totalScore));
@@ -78,6 +75,13 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
       }
     }
   }, [results.winner, config.soundEnabled, config.effectsEnabled]);
+
+  const handleMoodSelect = (mood: string) => {
+    const history: { date: string; score: number; mood: string }[] = JSON.parse(localStorage.getItem('sessionHistory') || '[]');
+    history.push({ date: new Date().toISOString(), score: totalScore, mood });
+    localStorage.setItem('sessionHistory', JSON.stringify(history));
+    setShowMoodModal(false);
+  };
 
   const handleExport = () => {
     const dataStr = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(results, null, 2));
@@ -160,6 +164,18 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
             🔄 Play Again
         </button>
       </div>
+      {showMoodModal && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/70">
+          <div className="bg-white p-6 rounded-lg text-black max-w-sm w-full text-center">
+            <h3 className="text-2xl mb-4">How do you feel about today's session?</h3>
+            <div className="flex justify-center gap-6 text-4xl">
+              <button onClick={() => handleMoodSelect('😊')} aria-label="Happy" className="hover:scale-110">😊</button>
+              <button onClick={() => handleMoodSelect('😐')} aria-label="Neutral" className="hover:scale-110">😐</button>
+              <button onClick={() => handleMoodSelect('😢')} aria-label="Sad" className="hover:scale-110">😢</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -11,9 +11,10 @@ interface SetupScreenProps {
   onStartGame: (config: GameConfig) => void;
   onAddCustomWords: (words: Word[]) => void;
   onViewAchievements: () => void;
+  onViewHistory: () => void;
 }
 
-const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements }) => {
+const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements, onViewHistory }) => {
   const avatars = [beeImg, bookImg, trophyImg];
   const getRandomAvatar = () => avatars[Math.floor(Math.random() * avatars.length)];
 
@@ -573,8 +574,9 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             <button onClick={() => handleStart(false)} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Custom Game</button>
             <button onClick={() => handleStart(true)} className="w-full bg-orange-500 hover:bg-orange-600 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Session Challenge</button>
         </div>
-        <div className="mt-4 text-center">
+        <div className="mt-4 text-center flex flex-col md:flex-row gap-4 justify-center">
             <button onClick={onViewAchievements} className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View Achievements</button>
+            <button onClick={onViewHistory} className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View History</button>
         </div>
       </div>
     </div>

--- a/spelling-bee-game.tsx
+++ b/spelling-bee-game.tsx
@@ -5,6 +5,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import HistoryScreen from './HistoryScreen';
 import useMusic from './utils/useMusic';
 
 // --- Main App Component ---
@@ -70,6 +71,10 @@ const SpellingBeeGame = () => {
         setGameState("achievements");
     };
 
+    const handleViewHistory = () => {
+        setGameState("history");
+    };
+
     const handleBackToSetup = () => {
         setGameState("setup");
     };
@@ -92,7 +97,7 @@ const SpellingBeeGame = () => {
     useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
 
     if (gameState === "setup") {
-        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} />;
+        return <SetupScreen onStartGame={handleStartGame} onAddCustomWords={handleAddCustomWords} onViewAchievements={handleViewAchievements} onViewHistory={handleViewHistory} />;
     }
     if (gameState === "playing") {
         return (
@@ -116,6 +121,9 @@ const SpellingBeeGame = () => {
     }
     if (gameState === "leaderboard") {
         return <LeaderboardScreen onBack={handleBackToSetup} />;
+    }
+    if (gameState === "history") {
+        return <HistoryScreen onBack={handleBackToSetup} />;
     }
     if (gameState === "achievements") {
         return <AchievementsScreen onBack={handleBackToSetup} />;


### PR DESCRIPTION
Implemented fresh on `main` in commit `4dabd74`.

What landed:
- Added a classroom comfort check on the Results screen.
- Stored the selected comfort rating on the existing session history entry.
- Extended the History screen with comfort counts and per-session comfort markers.
- Added unit coverage for updating a history entry with comfort data.

Verified:
- `npm run build`
- `npm run test:unit`
- `npm run test:e2e:chromium`
- GitHub Actions CI passed on `main`.
- GitHub Pages deploy passed on `main`.
- Live GitHub Pages e2e passed against https://mr-gill.github.io/spelling-bee-game/.

Closing this stale PR because the useful classroom-comfort feature is now present on `main` using the current history implementation.