### PR TITLE
Add hide names toggle and avatar-only scoreboard

### DIFF
--- a/GameScreen.tsx
+++ b/GameScreen.tsx
@@ -21,6 +21,7 @@ import OnScreenKeyboard from "./components/OnScreenKeyboard";
 import HintPanel from "./components/HintPanel";
 import AvatarSelector from "./components/AvatarSelector";
 import { audioManager } from "./utils/audio";
+import ScoreboardScreen from "./ScoreboardScreen";
 
 interface GameScreenProps {
   config: GameConfig;
@@ -448,20 +449,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ config, onEndGame }) => {
           {toast}
         </div>
       )}
-      <div className="absolute top-8 left-8 flex gap-8 items-center">
-        <img src="img/bee.svg" alt="Bee icon" className="w-12 h-12" />
-        {participants.map((p, index) => (
-          <div key={index} className="text-center scorecard">
-            <div className="text-2xl font-bold">{p.name}</div>
-            <div className="text-4xl font-bold text-yellow-300">
-              {"❤️".repeat(p.lives)}
-            </div>
-            <div className="text-xl font-bold text-green-400">
-              {p.points} pts
-            </div>
-          </div>
-        ))}
-      </div>
+      <ScoreboardScreen participants={participants} hideNames={config.hideNames} />
 
       {feedback.message && (
         <div

--- a/ScoreboardScreen.tsx
+++ b/ScoreboardScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Participant } from './types';
+
+interface ScoreboardScreenProps {
+  participants: Participant[];
+  hideNames?: boolean;
+}
+
+const ScoreboardScreen: React.FC<ScoreboardScreenProps> = ({ participants, hideNames }) => {
+  const shouldHide = hideNames ?? (typeof window !== 'undefined' && localStorage.getItem('hideNames') === 'true');
+  return (
+    <div className="absolute top-8 left-8 flex gap-8 items-center">
+      <img src="img/bee.svg" alt="Bee icon" className="w-12 h-12" />
+      {participants.map((p, index) => (
+        <div key={index} className="text-center scorecard">
+          <div className="text-2xl font-bold">
+            {shouldHide ? (
+              p.avatar ? (
+                <img
+                  src={p.avatar}
+                  alt={`Team ${index + 1}`}
+                  className="w-8 h-8 rounded-full mx-auto"
+                />
+              ) : (
+                `Team ${index + 1}`
+              )
+            ) : (
+              p.name
+            )}
+          </div>
+          <div className="text-4xl font-bold text-yellow-300">
+            {'❤️'.repeat(p.lives)}
+          </div>
+          <div className="text-xl font-bold text-green-400">{p.points} pts</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ScoreboardScreen;

--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GameConfig, Word } from './types';
 import { parseWordList } from './utils/parseWordList';
 import bookImg from './img/avatars/book.svg';
@@ -72,6 +72,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [progressionSpeed, setProgressionSpeed] = useState(1);
   const [theme, setTheme] = useState('light');
   const [teacherMode, setTeacherMode] = useState<boolean>(() => localStorage.getItem('teacherMode') === 'true');
+  const [hideNames, setHideNames] = useState<boolean>(() => localStorage.getItem('hideNames') === 'true');
   const [aiGrade, setAiGrade] = useState(5);
   const [aiTopic, setAiTopic] = useState('');
   const [aiCount, setAiCount] = useState(10);
@@ -93,6 +94,10 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     }
     localStorage.setItem('teacherMode', String(teacherMode));
   }, [teacherMode]);
+
+  useEffect(() => {
+    localStorage.setItem('hideNames', String(hideNames));
+  }, [hideNames]);
 
   useEffect(() => {
     setStartingLives(gameMode === 'team' ? 10 : 5);
@@ -356,6 +361,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
       skipPenaltyValue: options.skipPenaltyValue,
       soundEnabled: options.soundEnabled,
       effectsEnabled: options.effectsEnabled,
+      hideNames,
       difficultyLevel: options.initialDifficulty,
       progressionSpeed: options.progressionSpeed,
       musicStyle: options.musicStyle,
@@ -498,6 +504,10 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Teacher Mode 👩‍🏫</h2>
                 <label className="flex items-center gap-2 text-white"><input type="checkbox" checked={teacherMode} onChange={e => setTeacherMode(e.target.checked)} /><span>Enable larger fonts and spacing</span></label>
+            </div>
+            <div className="bg-white/10 p-6 rounded-lg">
+                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Hide Names 🙈</h2>
+                <label className="flex items-center gap-2 text-white"><input type="checkbox" checked={hideNames} onChange={e => setHideNames(e.target.checked)} /><span>Hide student names on scoreboard</span></label>
             </div>
              <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Music 🎵</h2>

--- a/types.ts
+++ b/types.ts
@@ -38,6 +38,7 @@ export interface GameConfig {
   skipPenaltyValue: number;
   soundEnabled: boolean;
   effectsEnabled: boolean;
+  hideNames: boolean;
 
   musicStyle: string;
   musicVolume: number;


### PR DESCRIPTION
Implemented fresh on `main` in commit `7f72f4e`.

What landed:
- Added a setup Privacy Display toggle for hiding names.
- Persisted the toggle in localStorage and setup presets.
- Hid participant names in the in-game score cards/current-turn label when enabled.
- Carried the hidden-name setting into the live scoreboard route.
- Added Playwright coverage for the privacy-display gameplay path.

Verified:
- `npm run build`
- `npm run test:unit`
- `npm run test:e2e:chromium`
- GitHub Actions CI passed on `main`.
- GitHub Pages deploy passed on `main`.
- Live GitHub Pages e2e passed against https://mr-gill.github.io/spelling-bee-game/.

Closing this stale PR because the useful privacy feature is now present on `main` without merging the old root-file diff.