### PR TITLE
feat: add AI word list generator

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { GameConfig, Word } from './types';
 import { parseWordList } from './utils/parseWordList';
 import bookImg from './img/avatars/book.svg';
+import WordListPrompt from './WordListPrompt';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -46,6 +47,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [timerDuration, setTimerDuration] = useState(30);
   const [customWordListText, setCustomWordListText] = useState('');
   const [parsedCustomWords, setParsedCustomWords] = useState<Word[]>([]);
+  const [showWordPrompt, setShowWordPrompt] = useState(false);
   const [missedWordsCollection, setMissedWordsCollection] = useState<Record<string, Word[]>>({});
   const [includeMissedWords, setIncludeMissedWords] = useState(false);
   const [error, setError] = useState('');
@@ -517,6 +519,12 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         
         <div className="bg-white/10 p-6 rounded-lg mb-8 mt-8">
             <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Add Custom Word List 📝</h2>
+            <button
+                onClick={() => setShowWordPrompt(true)}
+                className="mb-4 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+            >
+                Generate Word List
+            </button>
             <div className="mb-6">
                 <label htmlFor="bundled-list" className="block text-lg font-medium mb-2">Choose Bundled Word List</label>
                 <select id="bundled-list" value={selectedBundledList} onChange={e => setSelectedBundledList(e.target.value)} className="w-full p-2 rounded-md bg-white/20 text-white">
@@ -577,6 +585,12 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             <button onClick={onViewAchievements} className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View Achievements</button>
         </div>
       </div>
+      {showWordPrompt && (
+        <WordListPrompt
+          onAddWords={ws => setParsedCustomWords(prev => [...prev, ...ws])}
+          onClose={() => setShowWordPrompt(false)}
+        />
+      )}
     </div>
   );
 };

--- a/WordListPrompt.tsx
+++ b/WordListPrompt.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { Word } from './types';
+import { generateWords } from './api/aiWordGenerator';
+
+interface WordListPromptProps {
+  onAddWords: (words: Word[]) => void;
+  onClose: () => void;
+}
+
+const WordListPrompt: React.FC<WordListPromptProps> = ({ onAddWords, onClose }) => {
+  const [prompt, setPrompt] = useState('');
+  const [words, setWords] = useState<Word[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await generateWords(prompt);
+      setWords(result);
+    } catch (err) {
+      setError('Failed to generate words.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded-lg w-full max-w-lg text-black">
+        <h2 className="text-xl font-bold mb-2">AI Word List Generator</h2>
+        <textarea
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          className="w-full p-2 border rounded mb-2"
+          placeholder="Describe the words you want..."
+        />
+        <button
+          onClick={handleGenerate}
+          disabled={loading}
+          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          {loading ? 'Generating...' : 'Generate'}
+        </button>
+        {error && <p className="text-red-500 mt-2">{error}</p>}
+        <ul className="mt-4 space-y-2 max-h-60 overflow-y-auto">
+          {words.map((w, i) => (
+            <li key={i} className="flex justify-between items-center bg-gray-100 p-2 rounded">
+              <span>{w.word}</span>
+              <button
+                className="bg-green-500 hover:bg-green-600 text-white px-2 py-1 rounded"
+                onClick={() => onAddWords([w])}
+              >
+                Add to session
+              </button>
+            </li>
+          ))}
+        </ul>
+        <button
+          onClick={onClose}
+          className="mt-4 bg-gray-300 hover:bg-gray-400 px-4 py-2 rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WordListPrompt;

--- a/api/aiWordGenerator.ts
+++ b/api/aiWordGenerator.ts
@@ -1,0 +1,29 @@
+import { Word } from '../types';
+
+const API_URL = 'https://api.github.com/models/gpt-4o-mini-instruct';
+
+export async function generateWords(prompt: string): Promise<Word[]> {
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to generate words');
+  }
+
+  const data = await res.json();
+  const content = data?.choices?.[0]?.message?.content ?? '[]';
+  try {
+    return JSON.parse(content);
+  } catch (err) {
+    console.error('Failed to parse model response', content, err);
+    throw new Error('Invalid response format');
+  }
+}


### PR DESCRIPTION
## Summary
- add API helper to generate words from GitHub LLM endpoint
- create WordListPrompt component to request and insert AI words
- hook WordListPrompt into setup flow with new Generate Word List button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27ce0ece48332acba17273990cda6