### PR TITLE
Add prompt preset categories and prompt suggestion UI

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
-import { GameConfig, Word } from './types';
+import { GameConfig, Word, Participant } from './types';
 import { parseWordList } from './utils/parseWordList';
+import useRoster from './hooks/useRoster';
+import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
+import trophyImg from './img/avatars/trophy.svg';
+import WordListPrompt from './components/WordListPrompt';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -537,12 +541,12 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 </div>
             </div>
             <div className="mt-6">
-                <div className="flex flex-col md:flex-row gap-2">
+                <div className="flex flex-col md:flex-row gap-2 mb-2">
                     <input type="number" min={1} value={aiGrade} onChange={e => setAiGrade(Number(e.target.value))} className="p-2 rounded-md bg-white/20 text-white w-full md:w-24" placeholder="Grade" />
-                    <input type="text" value={aiTopic} onChange={e => setAiTopic(e.target.value)} className="p-2 rounded-md bg-white/20 text-white flex-1" placeholder="Topic (optional)" />
                     <input type="number" min={1} value={aiCount} onChange={e => setAiCount(Number(e.target.value))} className="p-2 rounded-md bg-white/20 text-white w-full md:w-24" placeholder="# Words" />
                     <button onClick={generateAIWords} disabled={aiLoading} className="bg-purple-500 hover:bg-purple-600 px-4 py-2 rounded w-full md:w-auto">{aiLoading ? 'Generating...' : 'Generate with AI'}</button>
                 </div>
+                <WordListPrompt value={aiTopic} onChange={setAiTopic} />
                 {aiError && <p className="text-red-300 mt-2">{aiError}</p>}
             </div>
             <div className="mt-4 text-sm text-gray-300">

--- a/components/WordListPrompt.tsx
+++ b/components/WordListPrompt.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { promptPresets, PromptCategory } from '../constants/promptPresets';
+
+interface WordListPromptProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const tabLabels: Record<PromptCategory | 'custom', string> = {
+  currentEvents: 'Current Events',
+  books: 'Books',
+  subjects: 'Subjects',
+  custom: 'Saved',
+};
+
+const WordListPrompt: React.FC<WordListPromptProps> = ({ value, onChange }) => {
+  const [activeTab, setActiveTab] = useState<PromptCategory | 'custom'>('currentEvents');
+  const [customPrompts, setCustomPrompts] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('customPrompts') || '[]');
+    } catch {
+      return [];
+    }
+  });
+
+  const categories = { ...promptPresets, custom: customPrompts } as Record<PromptCategory | 'custom', string[]>;
+  const tabs = Object.keys(categories) as (PromptCategory | 'custom')[];
+
+  const handleSelectPrompt = (prompt: string) => {
+    onChange(prompt);
+  };
+
+  const handleSavePrompt = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const updated = Array.from(new Set([...customPrompts, trimmed]));
+    setCustomPrompts(updated);
+    localStorage.setItem('customPrompts', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="flex-1">
+      <div className="flex gap-2 mb-2">
+        {tabs.map(tab => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-2 py-1 rounded ${activeTab === tab ? 'bg-yellow-300 text-black' : 'bg-white/20 text-white'}`}
+          >
+            {tabLabels[tab]}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2 mb-2">
+        {categories[activeTab].map(prompt => (
+          <button
+            key={prompt}
+            onClick={() => handleSelectPrompt(prompt)}
+            className="bg-purple-500 hover:bg-purple-600 text-white px-2 py-1 rounded"
+          >
+            {prompt}
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          className="p-2 rounded-md bg-white/20 text-white flex-1"
+          placeholder="Topic (optional)"
+        />
+        <button
+          onClick={handleSavePrompt}
+          className="bg-green-500 hover:bg-green-600 px-4 py-2 rounded-lg font-bold"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WordListPrompt;

--- a/constants/promptPresets.ts
+++ b/constants/promptPresets.ts
@@ -1,0 +1,19 @@
+export const promptPresets = {
+  currentEvents: [
+    'Climate change headlines',
+    'Global technology trends',
+    'Recent space exploration missions',
+  ],
+  books: [
+    'Harry Potter universe vocabulary',
+    'Words from classic literature',
+    'Themes from contemporary novels',
+  ],
+  subjects: [
+    'Science fair terminology',
+    'Mathematics concepts',
+    'World history events',
+  ],
+};
+
+export type PromptCategory = keyof typeof promptPresets;


### PR DESCRIPTION
## Summary
- add preset prompt lists for current events, books, and subjects
- build `WordListPrompt` component with tabbed suggestions and localStorage saving
- integrate prompt suggestions into setup screen for AI word list generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27ce2d9988332a4036066b08fe4ee