### PR TITLE
Add text extractor and passage upload for word list generation

### DIFF
--- a/components/WordListPrompt.tsx
+++ b/components/WordListPrompt.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import type { Word } from '../types';
+import { extractTextFromFile, generateWords } from '../utils/textExtractor';
+
+const WordListPrompt: React.FC = () => {
+  const [bookTitle, setBookTitle] = useState('');
+  const [passage, setPassage] = useState('');
+  const [words, setWords] = useState<Word[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await extractTextFromFile(file);
+      setPassage(text);
+    } catch (err) {
+      console.error('Failed to extract text', err);
+    }
+  };
+
+  const handleGenerate = async () => {
+    if (!bookTitle || !passage) return;
+    setLoading(true);
+    try {
+      const generated = await generateWords(passage, bookTitle);
+      setWords(generated);
+    } catch (err) {
+      console.error('Failed to generate words', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white/10 p-6 rounded-lg">
+      <div className="mb-4">
+        <label className="block mb-2 font-bold">Book Title</label>
+        <input
+          type="text"
+          value={bookTitle}
+          onChange={e => setBookTitle(e.target.value)}
+          className="w-full p-2 rounded-md bg-white/20 text-white"
+          placeholder="e.g., Alice in Wonderland"
+        />
+      </div>
+      <div className="mb-4">
+        <label className="block mb-2 font-bold">Paste Passage</label>
+        <textarea
+          rows={4}
+          value={passage}
+          onChange={e => setPassage(e.target.value)}
+          className="w-full p-2 rounded-md bg-white/20 text-white"
+          placeholder="Paste text here or upload a file below"
+        ></textarea>
+      </div>
+      <div className="mb-4">
+        <label className="block mb-2 font-bold">Upload Passage</label>
+        <input type="file" accept=".txt,.pdf" onChange={handleFile} className="w-full" />
+      </div>
+      <button
+        onClick={handleGenerate}
+        disabled={!bookTitle || !passage || loading}
+        className="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded-md disabled:opacity-50"
+      >
+        {loading ? 'Generating...' : 'Generate Words'}
+      </button>
+      {words.length > 0 && (
+        <pre className="mt-4 bg-black/30 p-4 rounded text-sm overflow-x-auto">
+          {JSON.stringify(words, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default WordListPrompt;
+

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,8 @@ export interface Word {
   prefix?: string;
   suffix?: string;
   pronunciation?: string;
+  /** Optional source the word list was generated from */
+  source?: string;
 }
 
 export interface Participant {

--- a/utils/textExtractor.ts
+++ b/utils/textExtractor.ts
@@ -1,0 +1,86 @@
+import type { Word } from '../types';
+
+/**
+ * Read text from a File. Supports plain text and PDF files.
+ */
+export const extractTextFromFile = async (file: File): Promise<string> => {
+  const lower = file.name.toLowerCase();
+  if (file.type === 'text/plain' || lower.endsWith('.txt')) {
+    return await file.text();
+  }
+  if (file.type === 'application/pdf' || lower.endsWith('.pdf')) {
+    try {
+      const pdfjs = await import('pdfjs-dist/legacy/build/pdf');
+      const data = await file.arrayBuffer();
+      const pdf = await pdfjs.getDocument({ data }).promise;
+      let text = '';
+      for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const content = await page.getTextContent();
+        text += content.items.map((item: any) => item.str).join(' ') + '\n';
+      }
+      return text;
+    } catch {
+      throw new Error('PDF extraction requires the optional pdfjs-dist dependency');
+    }
+  }
+  throw new Error('Unsupported file type');
+};
+
+const slugify = (title: string) => title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+/**
+ * Send passage text to the AI backend and return generated vocabulary words.
+ * Each word is tagged with the source book title and saved to the wordlists
+ * directory for future reuse.
+ */
+export const generateWords = async (passage: string, bookTitle: string): Promise<Word[]> => {
+  const prompt = `Extract key vocabulary words from the following passage and return a JSON array where each item has fields word, syllables (array), definition, origin, example, prefix, suffix, pronunciation.\n\n${passage}`;
+  const res = await fetch('https://api.github.com/models/gpt-4o-mini-instruct', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN || ''}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ messages: [{ role: 'user', content: prompt }] }),
+  });
+  const json = await res.json();
+  const content = json?.choices?.[0]?.message?.content || '[]';
+  let words: Word[] = [];
+  try {
+    words = JSON.parse(content);
+  } catch (err) {
+    console.error('Failed to parse model response', err);
+    throw err;
+  }
+  const tagged = words.map(w => ({ ...w, source: bookTitle }));
+  await saveWordList(bookTitle, tagged);
+  return tagged;
+};
+
+async function saveWordList(title: string, words: Word[]) {
+  if (typeof window !== 'undefined') {
+    const blob = new Blob([JSON.stringify(words, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${slugify(title)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    return;
+  }
+  const { writeFile } = await import('fs/promises');
+  const path = await import('path');
+  const filePath = path.join(process.cwd(), 'wordlists', `${slugify(title)}.json`);
+  await writeFile(filePath, JSON.stringify(words, null, 2), 'utf8');
+}
+
+/**
+ * Convenience wrapper that accepts either a string or File input and returns
+ * the extracted text. If a File is provided it will be read appropriately.
+ */
+export const extractText = async (input: string | File): Promise<string> => {
+  if (typeof input === 'string') return input;
+  return extractTextFromFile(input);
+};
+

--- a/wordlists/sample-book.json
+++ b/wordlists/sample-book.json
@@ -1,0 +1,13 @@
+[
+  {
+    "word": "example",
+    "syllables": ["ex", "am", "ple"],
+    "definition": "a thing characteristic of its kind",
+    "origin": "Latin",
+    "example": "This is an example sentence.",
+    "prefix": "",
+    "suffix": "",
+    "pronunciation": "ig-ZAM-pul",
+    "source": "Sample Book"
+  }
+]


### PR DESCRIPTION
## Summary
- support tagging words with book source
- add textExtractor util to read text or PDF and generate word lists via AI backend
- provide WordListPrompt UI with passage upload and word generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27ce3d9f883328a93a46b966c96f9