### PR TITLE
Add preset management to setup screen

### DIFF
--- a/SetupScreen.tsx
+++ b/SetupScreen.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
-import { GameConfig, Word } from './types';
-import { parseWordList } from './utils/parseWordList';
+import React, { useState, useEffect } from 'react';
+import { Word, Participant, GameConfig } from './types';
+import beeImg from './img/avatars/bee.svg';
 import bookImg from './img/avatars/book.svg';
+import trophyImg from './img/avatars/trophy.svg';
+import { parseWordList as parseWordListUtil } from './utils/parseWordList';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -26,23 +28,6 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   ];
 
   const [teams, setTeams] = useState<Participant[]>(getDefaultTeams());
-  const {
-    participants: teams,
-    addParticipant: addTeamParticipant,
-    removeParticipant: removeTeam,
-    updateName: updateTeamName,
-    clear: clearTeams,
-  } = useRoster('teams', getDefaultTeams());
-
-  const {
-    participants: students,
-    addParticipant: addStudentParticipant,
-    removeParticipant: removeStudent,
-    updateName: updateStudentName,
-    clear: clearStudents,
-  } = useRoster('students', []);
-
-  const [gameMode, setGameMode] = useState<'team' | 'individual'>('team');
   const [timerDuration, setTimerDuration] = useState(30);
   const [customWordListText, setCustomWordListText] = useState('');
   const [parsedCustomWords, setParsedCustomWords] = useState<Word[]>([]);
@@ -77,8 +62,15 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [aiCount, setAiCount] = useState(10);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiError, setAiError] = useState('');
-  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
-  const [selectedVoice, setSelectedVoice] = useState<string>(() => localStorage.getItem('selectedVoice') ?? '');
+
+  const [presets, setPresets] = useState<Record<string, any>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('presets') || '{}');
+    } catch {
+      return {};
+    }
+  });
+  const [selectedPreset, setSelectedPreset] = useState('');
 
   const applyTheme = (t: string) => {
     document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
@@ -115,21 +107,6 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   useEffect(() => localStorage.setItem('soundEnabled', String(soundEnabled)), [soundEnabled]);
   useEffect(() => localStorage.setItem('musicStyle', musicStyle), [musicStyle]);
   useEffect(() => localStorage.setItem('musicVolume', String(musicVolume)), [musicVolume]);
-  useEffect(() => {
-    if (selectedVoice) {
-      localStorage.setItem('selectedVoice', selectedVoice);
-    } else {
-      localStorage.removeItem('selectedVoice');
-    }
-  }, [selectedVoice]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || !('speechSynthesis' in window)) return;
-    const loadVoices = () => setVoices(window.speechSynthesis.getVoices());
-    loadVoices();
-    window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
-    return () => window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
-  }, []);
 
   const updateTeams = (newTeams: Participant[]) => {
     setTeams(newTeams);
@@ -159,38 +136,43 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
 
   const createParticipant = (name: string, difficulty: number): Participant => ({
     name: name.trim(), lives: startingLives, points: 0, difficultyLevel: difficulty, streak: 0, attempted: 0, correct: 0, wordsAttempted: 0, wordsCorrect: 0, avatar: getRandomAvatar()
-
-  const [options, setOptions] = useState<OptionsState>({
-    skipPenaltyType: 'lives',
-    skipPenaltyValue: 1,
-    initialDifficulty: 0,
-    progressionSpeed: 1,
-    soundEnabled: localStorage.getItem('soundEnabled') !== 'false',
-    effectsEnabled: true,
-    theme: localStorage.getItem('theme') ?? 'light',
-    teacherMode: localStorage.getItem('teacherMode') === 'true',
-    musicStyle: localStorage.getItem('musicStyle') ?? 'Funk',
-    musicVolume: parseFloat(localStorage.getItem('musicVolume') ?? '1'),
   });
 
-  const createParticipant = (name: string, difficulty: number): Participant => ({
-    name: name.trim(),
-    lives: 5,
-    points: 0,
-    difficultyLevel: difficulty,
-    streak: 0,
-    attempted: 0,
-    correct: 0,
-    wordsAttempted: 0,
-    wordsCorrect: 0,
-    avatar: getRandomAvatar(),
-  });
+  const addTeam = () => updateTeams([...teams, createParticipant('', 0)]);
+  const removeTeam = (index: number) => updateTeams(teams.filter((_, i) => i !== index));
+  const updateTeamName = (index: number, name: string) => {
+    const newTeams = teams.map((team, i) => (i === index ? { ...team, name } : team));
+    updateTeams(newTeams);
+  };
 
-  const addTeam = () => addTeamParticipant(createParticipant('', 0));
+  const addStudent = () => {
+    if (studentName.trim()) {
+      updateStudents([...students, createParticipant(studentName, initialDifficulty)]);
+      setStudentName('');
+    }
+  };
 
-  const clearRoster = () => {
-    clearTeams();
-    clearStudents();
+  const removeStudent = (index: number) => updateStudents(students.filter((_, i) => i !== index));
+  const updateStudentName = (index: number, name: string) => {
+    const newStudents = students.map((student, i) => (i === index ? { ...student, name } : student));
+    updateStudents(newStudents);
+  };
+
+  const parseStudentNames = (text: string) =>
+    text.split(/\r?\n/).flatMap(line => line.split(',')).map(name => name.trim()).filter(name => name !== '');
+
+  const addBulkStudents = () => {
+    const names = parseStudentNames(bulkStudentText);
+    const existing = new Set(students.map(s => s.name));
+    const uniqueNames = Array.from(new Set(names)).filter(name => !existing.has(name));
+    if (uniqueNames.length === 0) {
+      setBulkStudentError('No new unique names detected.');
+      return;
+    }
+    const newStudents = uniqueNames.map(name => createParticipant(name, initialDifficulty));
+    updateStudents([...students, ...newStudents]);
+    setBulkStudentText('');
+    setBulkStudentError('');
   };
 
   const randomizeTeams = () => {
@@ -303,6 +285,68 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
 
   const missedWordCount = Object.values(missedWordsCollection).reduce((acc, arr) => acc + arr.length, 0);
 
+  const handleSavePreset = () => {
+    const name = prompt('Preset name?');
+    if (!name) return;
+    const preset = {
+      gameMode,
+      teams,
+      students,
+      startingLives,
+      timerDuration,
+      skipPenaltyType,
+      skipPenaltyValue,
+      soundEnabled,
+      effectsEnabled,
+      musicStyle,
+      musicVolume,
+      initialDifficulty,
+      progressionSpeed,
+      theme,
+      teacherMode,
+    };
+    const updated = { ...presets, [name]: preset };
+    setPresets(updated);
+    localStorage.setItem('presets', JSON.stringify(updated));
+    setSelectedPreset(name);
+  };
+
+  const handleLoadPreset = (name: string) => {
+    const preset = presets[name];
+    if (!preset) return;
+    setGameMode(preset.gameMode);
+    setStartingLives(preset.startingLives);
+    setTimerDuration(preset.timerDuration);
+    setSkipPenaltyType(preset.skipPenaltyType);
+    setSkipPenaltyValue(preset.skipPenaltyValue);
+    setSoundEnabled(preset.soundEnabled);
+    setEffectsEnabled(preset.effectsEnabled);
+    setMusicStyle(preset.musicStyle);
+    setMusicVolume(preset.musicVolume);
+    setInitialDifficulty(preset.initialDifficulty);
+    setProgressionSpeed(preset.progressionSpeed);
+    setTheme(preset.theme);
+    applyTheme(preset.theme);
+    setTeacherMode(preset.teacherMode);
+    updateTeams(preset.teams || []);
+    updateStudents(preset.students || []);
+  };
+
+  const handleDeletePreset = (name: string) => {
+    const updated = { ...presets };
+    delete updated[name];
+    setPresets(updated);
+    localStorage.setItem('presets', JSON.stringify(updated));
+    if (selectedPreset === name) setSelectedPreset('');
+  };
+
+  const handlePresetChange = (name: string) => {
+    setSelectedPreset(name);
+    if (name) {
+      handleLoadPreset(name);
+    }
+  };
+
   const handleStart = async (isSessionChallenge = false) => {
     let challengeWords: Word[] = [];
     if (isSessionChallenge) {
@@ -325,16 +369,16 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             setError('Please add at least two teams with names.');
             return;
         }
-        finalParticipants = trimmedTeams.map(t => ({...t, difficultyLevel: options.initialDifficulty}));
+        finalParticipants = trimmedTeams.map(t => ({...t, difficultyLevel: initialDifficulty}));
     } else {
         const trimmedStudents = students.filter(student => student.name.trim() !== "");
         if (trimmedStudents.length < 1 && isSessionChallenge) {
-             finalParticipants = [createParticipant('Player 1', options.initialDifficulty)];
+             finalParticipants = [createParticipant('Player 1', initialDifficulty)];
         } else if (trimmedStudents.length < 2 && !isSessionChallenge) {
             setError('Please add at least two students for a custom game.');
             return;
         } else {
-             finalParticipants = trimmedStudents.map(s => ({...s, difficultyLevel: options.initialDifficulty}));
+             finalParticipants = trimmedStudents.map(s => ({...s, difficultyLevel: initialDifficulty}));
         }
     }
 
@@ -350,33 +394,43 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     
     const config: GameConfig = {
       participants: finalParticipants,
-      gameMode,
-      timerDuration,
-      skipPenaltyType: options.skipPenaltyType,
-      skipPenaltyValue: options.skipPenaltyValue,
-      soundEnabled: options.soundEnabled,
-      effectsEnabled: options.effectsEnabled,
-      difficultyLevel: options.initialDifficulty,
-      progressionSpeed: options.progressionSpeed,
-      musicStyle: options.musicStyle,
-      musicVolume: options.musicVolume,
+      gameMode, timerDuration, skipPenaltyType, skipPenaltyValue, soundEnabled, effectsEnabled, difficultyLevel: initialDifficulty, progressionSpeed, musicStyle, musicVolume,
     };
     onStartGame(config);
   };
   
   return (
-    <div className="min-h-screen p-8 text-white font-body">
+    <div className="min-h-screen p-8 text-white">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
             <div className="flex items-center justify-center gap-3 mb-4">
                 <img src="icons/icon.svg" alt="Bee mascot" className="w-12 h-12 md:w-16 md:h-16" />
-                <h1 className="text-4xl md:text-6xl font-bold text-yellow-300 uppercase font-heading">🏆 SPELLING BEE CHAMPIONSHIP</h1>
+                <h1 className="text-4xl md:text-6xl font-bold text-yellow-300">🏆 SPELLING BEE CHAMPIONSHIP</h1>
             </div>
             <p className="text-xl md:text-2xl">Get ready to spell your way to victory!</p>
         </div>
 
         <div className="bg-white/10 p-6 rounded-lg mb-8">
-          <h2 className="text-2xl font-bold mb-4 text-center uppercase font-heading">Select Game Mode 🎮</h2>
+          <h2 className="text-2xl font-bold mb-4">Presets 💾</h2>
+          <div className="flex flex-col md:flex-row gap-2 items-center">
+            <select
+              value={selectedPreset}
+              onChange={e => handlePresetChange(e.target.value)}
+              className="flex-grow p-2 rounded-md bg-white/20 text-white"
+            >
+              <option value="">-- Select preset --</option>
+              {Object.keys(presets).map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+            <button onClick={handleSavePreset} className="bg-green-500 hover:bg-green-600 px-4 py-2 rounded w-full md:w-auto">Save Preset</button>
+            <button onClick={() => handleLoadPreset(selectedPreset)} disabled={!selectedPreset} className="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded w-full md:w-auto disabled:opacity-50">Load Preset</button>
+            <button onClick={() => handleDeletePreset(selectedPreset)} disabled={!selectedPreset} className="bg-red-500 hover:bg-red-600 px-4 py-2 rounded w-full md:w-auto disabled:opacity-50">Delete</button>
+          </div>
+        </div>
+
+        <div className="bg-white/10 p-6 rounded-lg mb-8">
+          <h2 className="text-2xl font-bold mb-4 text-center">Select Game Mode 🎮</h2>
           <div className="flex justify-center gap-4">
             <button onClick={() => setGameMode('team')} className={`px-6 py-3 rounded-lg text-xl font-bold ${gameMode === 'team' ? 'bg-yellow-300 text-black' : 'bg-blue-500 hover:bg-blue-400'}`}>Team</button>
             <button onClick={() => setGameMode('individual')} className={`px-6 py-3 rounded-lg text-xl font-bold ${gameMode === 'individual' ? 'bg-yellow-300 text-black' : 'bg-blue-500 hover:bg-blue-400'}`}>Individual</button>
@@ -384,15 +438,18 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
         </div>
         
         <div className="bg-white/10 p-6 rounded-lg mb-8">
-          <h2 className="text-2xl font-bold mb-4 uppercase font-heading">{gameMode === 'team' ? 'Teams 👥' : 'Students 🧑‍🎓'}</h2>
+          <h2 className="text-2xl font-bold mb-4">{gameMode === 'team' ? 'Teams 👥' : 'Students 🧑‍🎓'}</h2>
           {gameMode === 'team' ? (
-            <TeamForm
-              teams={teams}
-              avatars={avatars}
-              addTeam={addTeam}
-              removeTeam={removeTeam}
-              updateTeamName={updateTeamName}
-            />
+            <>
+              {teams.map((team, index) => (
+                <div key={index} className="flex items-center gap-2 mb-2">
+                  <img src={team.avatar || avatars[0]} alt="avatar" className="w-8 h-8 rounded-full" />
+                  <input type="text" value={team.name} onChange={e => updateTeamName(index, e.target.value)} placeholder={`Team ${index + 1} Name`} className="flex-grow p-2 rounded-md bg-white/20 text-white" />
+                  {teams.length > 1 && (<button onClick={() => removeTeam(index)} className="px-2 py-1 bg-red-500 hover:bg-red-600 rounded">Remove</button>)}
+                </div>
+              ))}
+              <button onClick={addTeam} className="mt-2 bg-green-500 hover:bg-green-600 px-4 py-2 rounded">Add Team</button>
+            </>
           ) : (
             <>
               <div className="flex gap-4 mb-4">
@@ -422,30 +479,17 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 </div>
               ))}
             </>
-            <StudentRoster
-              students={students}
-              avatars={avatars}
-              addParticipant={addStudentParticipant}
-              removeStudent={removeStudent}
-              updateStudentName={updateStudentName}
-              createParticipant={createParticipant}
-              initialDifficulty={options.initialDifficulty}
-            />
           )}
           <button onClick={clearRoster} className="mt-4 bg-red-500 hover:bg-red-600 px-4 py-2 rounded">Clear Saved Roster</button>
         </div>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
             <div className="bg-white/10 p-6 rounded-lg">
-<<<<<<< HEAD
                 <h2 className="text-2xl font-bold mb-4">Starting Lives ❤️</h2>
                 <input type="number" min={1} value={startingLives} onChange={e => setStartingLives(Number(e.target.value))} className="p-2 rounded-md bg-white/20 text-white w-full" />
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4">Skip Penalty ⏭️</h2>
-=======
-                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Skip Penalty ⏭️</h2>
->>>>>>> origin/codex/import-google-fonts-and-configure-tailwind
                 <div className="flex gap-4">
                     <select value={skipPenaltyType} onChange={e => setSkipPenaltyType(e.target.value as 'lives' | 'points')} className="p-2 rounded-md bg-white/20 text-white">
                         <option value="lives">Lives</option>
@@ -455,7 +499,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 </div>
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Difficulty Settings 🎚️</h2>
+                <h2 className="text-2xl font-bold mb-4">Difficulty Settings 🎚️</h2>
                 <div className="flex gap-4">
                     <div>
                         <label className="block mb-2">Initial Difficulty</label>
@@ -472,23 +516,12 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 </div>
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Audio & Effects 🔊✨</h2>
+                <h2 className="text-2xl font-bold mb-4">Audio & Effects 🔊✨</h2>
                 <label className="flex items-center space-x-3 mb-2"><input type="checkbox" checked={soundEnabled} onChange={e => setSoundEnabled(e.target.checked)} /><span>Enable Sound</span></label>
                 <label className="flex items-center space-x-3"><input type="checkbox" checked={effectsEnabled} onChange={e => setEffectsEnabled(e.target.checked)} /><span>Enable Visual Effects</span></label>
-                {voices.length > 0 && (
-                    <div className="mt-4">
-                        <label className="block mb-2">Voice</label>
-                        <select value={selectedVoice} onChange={e => setSelectedVoice(e.target.value)} className="p-2 rounded-md bg-white/20 text-white">
-                            <option value="">Default</option>
-                            {voices.map(v => (
-                                <option key={v.voiceURI} value={v.voiceURI}>{`${v.name} (${v.lang})`}</option>
-                            ))}
-                        </select>
-                    </div>
-                )}
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Theme 🎨</h2>
+                <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>
                 <select value={theme} onChange={e => { const t = e.target.value; setTheme(t); localStorage.setItem('theme', t); applyTheme(t); }} className="p-2 rounded-md bg-white/20 text-white">
                     <option value="light">Light</option>
                     <option value="dark">Dark</option>
@@ -496,11 +529,11 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 </select>
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Teacher Mode 👩‍🏫</h2>
+                <h2 className="text-2xl font-bold mb-4">Teacher Mode 👩‍🏫</h2>
                 <label className="flex items-center gap-2 text-white"><input type="checkbox" checked={teacherMode} onChange={e => setTeacherMode(e.target.checked)} /><span>Enable larger fonts and spacing</span></label>
             </div>
              <div className="bg-white/10 p-6 rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Music 🎵</h2>
+                <h2 className="text-2xl font-bold mb-4">Music 🎵</h2>
                 <div className="mb-4">
                     <label className="block mb-2">Style</label>
                     <select value={musicStyle} onChange={e => setMusicStyle(e.target.value)} className="p-2 rounded-md bg-white/20 text-white">
@@ -513,10 +546,9 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
                 </div>
             </div>
         </div>
-        <GameOptions options={options} setOptions={setOptions} />
         
         <div className="bg-white/10 p-6 rounded-lg mb-8 mt-8">
-            <h2 className="text-2xl font-bold mb-4 uppercase font-heading">Add Custom Word List 📝</h2>
+            <h2 className="text-2xl font-bold mb-4">Add Custom Word List 📝</h2>
             <div className="mb-6">
                 <label htmlFor="bundled-list" className="block text-lg font-medium mb-2">Choose Bundled Word List</label>
                 <select id="bundled-list" value={selectedBundledList} onChange={e => setSelectedBundledList(e.target.value)} className="w-full p-2 rounded-md bg-white/20 text-white">
@@ -547,9 +579,6 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             </div>
             <div className="mt-4 text-sm text-gray-300">
                 <p><strong>Format:</strong> The first row should be headers: `word`, `syllables`, `definition`, `origin`, `example`, `prefix`, `suffix`, `pronunciation`.</p>
-                <div className="mt-2">
-                    <a href="wordlists/example.csv" download className="inline-block bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">Download Template</a>
-                </div>
             </div>
             <div className="mt-2">
               <a href="wordlists/example.csv" download className="inline-block bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">


### PR DESCRIPTION
Implemented fresh on `main` in commit `9b97ac9`.

The old branch had drifted from the current setup screen, so I added a clean localStorage-based preset flow:

- Save named setup presets
- Load saved presets back into the setup form
- Delete presets
- Presets include roster, mode, timers, skip penalty, audio/effects, music, difficulty, theme, and teacher mode
- Added Playwright coverage for saving and loading a preset option

Verified with local build, unit tests, Chromium e2e, CI, GitHub Pages deploy, and live Pages e2e.