### PR TITLE
feat: configure audio and game setup on start

### DIFF
--- a/src/GameScreen.tsx
+++ b/src/GameScreen.tsx
@@ -7,7 +7,7 @@ import {
   Team,
   GameResults,
   defaultAchievements,
-} from "./types";
+} from "./types.ts";
 import correctSoundFile from "../audio/correct.mp3";
 import wrongSoundFile from "../audio/wrong.mp3";
 import timeoutSoundFile from "../audio/timeout.mp3";

--- a/src/spelling-bee-game.tsx
+++ b/src/spelling-bee-game.tsx
@@ -7,8 +7,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 
 // Import types
-import type { GameConfig } from './types/game';
-import type { WordType } from './types/word';
+import type { GameConfig } from './types';
 
 // Import global styles
 import './tailwind.css';
@@ -37,23 +36,31 @@ const SpellingBeeGame = () => {
   }, []);
   const [gameState, setGameState] = useState('setup');
   const [gameConfig, setGameConfig] = useState<GameConfig | null>(null);
+  const [musicStyle, setMusicStyle] = useState('');
+  const [musicVolume, setMusicVolume] = useState(1);
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [isMusicPlaying, setIsMusicPlaying] = useState(false);
   
   // Initialize game with configuration
-  const handleStartGame = (config: Omit<GameConfig, 'wordList'>) => {
-    // Create a default word list for now
-    const defaultWordList: WordType[] = [];
-    
-    const fullConfig: GameConfig = {
-      ...config,
-      wordList: defaultWordList,
+  const handleStartGame = (config: GameConfig & { customWords?: any }) => {
+    const wordDatabase = config.wordDatabase || { easy: [], medium: [], tricky: [] };
+    const customWords = config.customWords || { easy: [], medium: [], tricky: [] };
+
+    const finalWordDatabase = config.dailyChallenge ? customWords : {
+        easy: [...wordDatabase.easy, ...customWords.easy],
+        medium: [...wordDatabase.medium, ...customWords.medium],
+        tricky: [...wordDatabase.tricky, ...customWords.tricky],
     };
-    
-    setGameConfig(fullConfig);
-    setGameState('playing');
+    setGameConfig({ ...config, wordDatabase: finalWordDatabase });
+    setMusicStyle(config.musicStyle);
+    setMusicVolume(config.musicVolume);
+    setSoundEnabled(config.soundEnabled);
+    setIsMusicPlaying(true);
+    setGameState("playing");
   };
   
   // Handle adding custom words
-  const handleAddCustomWords = (words: WordType[]) => {
+  const handleAddCustomWords = (words: any[]) => {
     console.log('Adding custom words:', words);
     // Implement custom words logic here
   };

--- a/tests/GameScreen.test.js
+++ b/tests/GameScreen.test.js
@@ -1,0 +1,63 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+const esbuild = require('esbuild');
+const path = require('path');
+const Module = require('module');
+
+test('GameScreen mounts with minimal config without runtime errors', () => {
+  global.localStorage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  global.document = {
+    body: { classList: { add: () => {}, remove: () => {} } },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  const result = esbuild.buildSync({
+    entryPoints: [path.join(__dirname, '../src/GameScreen.tsx')],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    write: false,
+    loader: { '.ts': 'ts', '.tsx': 'tsx', '.mp3': 'dataurl', '.svg': 'dataurl' },
+    external: ['react', 'react-dom']
+  });
+  const code = result.outputFiles[0].text;
+  const m = new Module('');
+  m.paths = Module._nodeModulePaths(process.cwd());
+  m._compile(code, 'GameScreen.js');
+  const GameScreen = m.exports.default;
+  const config = {
+    participants: [{
+      name: 'Test',
+      lives: 1,
+      points: 0,
+      difficultyLevel: 1,
+      streak: 0,
+      attempted: 0,
+      correct: 0,
+      wordsAttempted: 0,
+      wordsCorrect: 0,
+    }],
+    gameMode: 'individual',
+    timerDuration: 60,
+    wordDatabase: { easy: [], medium: [], tricky: [] },
+    skipPenaltyType: 'lives',
+    skipPenaltyValue: 0,
+    soundEnabled: true,
+    effectsEnabled: true,
+    musicStyle: 'Funk',
+    musicVolume: 0.5,
+    difficultyLevel: 1,
+    progressionSpeed: 1,
+  };
+  assert.doesNotThrow(() => {
+    ReactDOMServer.renderToString(
+      React.createElement(GameScreen, { config, onEndGame: () => {} })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- merge word databases on game start and initialize audio settings
- ensure GameScreen renders without runtime errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33be2685c8332803822d0cc9b757b