### PR TITLE
chore: reference results screen typescript

### DIFF
--- a/src/spelling-bee-game.tsx
+++ b/src/spelling-bee-game.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import LeaderboardScreen from './LeaderboardScreen';
 import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
-import ResultsScreen from './ResultsScreen';
+import ResultsScreen from './ResultsScreen.tsx';
 import AchievementsScreen from './AchievementsScreen';
 import ShopScreen from '../ShopScreen';
 import useMusic from './utils/useMusic';


### PR DESCRIPTION
## Summary
- reference ResultsScreen.tsx explicitly in app import

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b33f0a0f708332b2f607cc83e33c8d