### PR TITLE
feat: add session history view

### DIFF
--- a/src/HistoryScreen.tsx
+++ b/src/HistoryScreen.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+
+interface SessionEntry {
+  date: string;
+  score: number;
+  duration?: number;
+}
+
+interface HistoryScreenProps {
+  onBack: () => void;
+}
+
+const HistoryScreen: React.FC<HistoryScreenProps> = ({ onBack }) => {
+  const [history, setHistory] = useState<SessionEntry[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('sessionHistory');
+    if (stored) {
+      try {
+        setHistory(JSON.parse(stored));
+      } catch {
+        setHistory([]);
+      }
+    }
+  }, []);
+
+  const handleClearHistory = () => {
+    localStorage.removeItem('sessionHistory');
+    setHistory([]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white text-center flex flex-col items-center justify-center font-body">
+      <h1 className="text-6xl font-bold mb-8 text-yellow-300 uppercase font-sans">📘 Session History</h1>
+      <div className="bg-white/10 p-8 rounded-lg w-full max-w-md">
+        {history.length === 0 ? (
+          <div className="text-xl">No session history.</div>
+        ) : (
+          <ul className="text-xl space-y-2">
+            {history.map((entry, index) => (
+              <li key={index} className="flex justify-between">
+                <span>{new Date(entry.date).toLocaleString()}</span>
+                <span className="text-yellow-300">
+                  {entry.score} pts{entry.duration !== undefined && ` / ${entry.duration}s`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="flex gap-4 mt-8">
+        <button onClick={onBack} className="bg-blue-500 hover:bg-blue-600 px-8 py-4 rounded-xl text-2xl font-bold">
+          Back
+        </button>
+        {history.length > 0 && (
+          <button onClick={handleClearHistory} className="bg-red-500 hover:bg-red-600 px-8 py-4 rounded-xl text-2xl font-bold">
+            Clear History
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HistoryScreen;
+

--- a/src/ResultsScreen.tsx
+++ b/src/ResultsScreen.tsx
@@ -53,8 +53,10 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
   }, [results, config.dailyChallenge, bonus]);
 
   useEffect(() => {
-    const history: { date: string; score: number }[] = JSON.parse(localStorage.getItem('sessionHistory') || '[]');
-    history.push({ date: new Date().toISOString(), score: totalScore });
+    const history: { date: string; score: number; duration: number }[] = JSON.parse(
+      localStorage.getItem('sessionHistory') || '[]'
+    );
+    history.push({ date: new Date().toISOString(), score: totalScore, duration: results.duration || 0 });
     localStorage.setItem('sessionHistory', JSON.stringify(history));
 
     const storedBest = Number(localStorage.getItem('bestClassScore') || '0');
@@ -65,7 +67,7 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, config, onRestar
     } else {
       setBestClassScore(storedBest);
     }
-  }, [totalScore]);
+  }, [totalScore, results.duration]);
 
   useEffect(() => {
     // Play sound and show confetti if there's a winner and effects are enabled

--- a/src/SetupScreen.tsx
+++ b/src/SetupScreen.tsx
@@ -20,6 +20,8 @@ interface SetupScreenProps {
   onStartGame: (config: GameConfig) => void;
   onAddCustomWords: (words: any[]) => void;
   onViewAchievements: () => void;
+  onViewHistory: () => void;
+  onViewShop?: () => void;
 }
 
 // Using direct paths to assets in the public directory
@@ -30,7 +32,7 @@ const trophyImg = '/img/trophy.svg';
 // Available avatars for participants
 const availableAvatars = [beeImg, bookImg, trophyImg];
 
-const SetupScreen: FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements }) => {
+const SetupScreen: FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords, onViewAchievements, onViewHistory }) => {
 
   const [gameMode, setGameMode] = useState<GameMode>('team');
   const [startingLives, setStartingLives] = useState(10);
@@ -779,8 +781,19 @@ const handleParticipantRemove = (index: number) => {
           <button onClick={() => handleStart(false)} className="w-full bg-yellow-300 hover:bg-yellow-400 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Custom Game</button>
           <button onClick={() => handleStart(true)} className="w-full bg-orange-500 hover:bg-orange-600 text-black px-6 py-4 rounded-xl text-2xl font-bold">Start Session Challenge</button>
         </div>
-        <div className="mt-4 text-center">
-          <button onClick={onViewAchievements} className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold">View Achievements</button>
+        <div className="mt-4 text-center flex flex-col sm:flex-row gap-4 justify-center">
+          <button
+            onClick={onViewAchievements}
+            className="bg-purple-500 hover:bg-purple-600 text-white px-6 py-3 rounded-xl text-xl font-bold"
+          >
+            View Achievements
+          </button>
+          <button
+            onClick={onViewHistory}
+            className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-xl text-xl font-bold"
+          >
+            View History
+          </button>
         </div>
       </div>
     </div>

--- a/src/spelling-bee-game.tsx
+++ b/src/spelling-bee-game.tsx
@@ -5,6 +5,7 @@ import SetupScreen from './SetupScreen';
 import GameScreen from './GameScreen';
 import ResultsScreen from './ResultsScreen';
 import AchievementsScreen from './AchievementsScreen';
+import HistoryScreen from './HistoryScreen';
 import ShopScreen from '../ShopScreen';
 import useMusic from './utils/useMusic';
 import { AudioProvider } from './AudioContext';
@@ -102,6 +103,10 @@ const SpellingBeeGame = () => {
     setGameState('achievements');
   };
 
+  const handleViewHistory = () => {
+    setGameState('history');
+  };
+
   const handleViewShop = () => {
     setGameState('shop');
   };
@@ -133,6 +138,7 @@ const SpellingBeeGame = () => {
         onStartGame={handleStartGame}
         onAddCustomWords={handleAddCustomWords}
         onViewAchievements={handleViewAchievements}
+        onViewHistory={handleViewHistory}
         onViewShop={() => handleViewShop()}
       />
     );
@@ -169,6 +175,9 @@ const SpellingBeeGame = () => {
   }
   if (gameState === 'achievements') {
     return <AchievementsScreen onBack={handleBackToSetup} />;
+  }
+  if (gameState === 'history') {
+    return <HistoryScreen onBack={handleBackToSetup} />;
   }
   if (gameState === 'shop') {
     return <ShopScreen onBack={handleBackToSetup} />;


### PR DESCRIPTION
## Summary
- add HistoryScreen component to display past sessions and clear history
- store session duration alongside date and score
- wire up history view via setup menu and routing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33f08bcf08332b254ddd7757aa4c5