### PR TITLE
feat: apply new typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Preload critical fonts -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap"></noscript>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Readex+Pro:wght@700&family=Inclusive+Sans:wght@400;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Readex+Pro:wght@700&family=Inclusive+Sans:wght@400;700&display=swap"></noscript>
     
     <!-- CSS -->
     <link rel="stylesheet" href="./tailwind.css">

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -13,14 +13,13 @@
   }
 
   body {
-    @apply bg-gradient-to-br from-bee-yellow-50 to-bee-yellow-100 text-bee-black-500 dark:from-bee-black-900 dark:to-bee-black-800 dark:text-gray-100 transition-all duration-300;
+    @apply font-body bg-gradient-to-br from-bee-yellow-50 to-bee-yellow-100 text-bee-black-500 dark:from-bee-black-900 dark:to-bee-black-800 dark:text-gray-100 transition-all duration-300;
     background-attachment: fixed;
   }
 
   /* Typography */
   h1, h2, h3, h4, h5, h6 {
-    @apply font-bold leading-tight tracking-tight text-bee-black-700 dark:text-white;
-    font-family: 'Poppins', system-ui, -apple-system, sans-serif;
+    @apply font-heading font-bold uppercase leading-tight tracking-tight text-bee-black-700 dark:text-white;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
   }
 

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 /* Modern styles for Spelling Bee Championship */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fredoka+One&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Readex+Pro:wght@700&family=Inclusive+Sans:wght@400;700&display=swap');
 
 :root {
   /* Light Theme */
@@ -59,7 +59,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: 'Inclusive Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.5;
@@ -71,11 +71,12 @@ body {
 
 /* Typography */
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Readex Pro', sans-serif;
   font-weight: 700;
   line-height: 1.2;
   margin-bottom: var(--spacing-md);
   color: var(--text);
+  text-transform: uppercase;
 }
 
 h1 { font-size: 2.5rem; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        heading: ['Readex Pro', 'sans-serif'],
+        body: ['Inclusive Sans', 'sans-serif'],
+      },
       animation: {
         'bounce-slow': 'bounce 3s infinite',
         'float': 'float 6s ease-in-out infinite',


### PR DESCRIPTION
## Summary
- load Readex Pro and Inclusive Sans from Google Fonts
- set headings in uppercase Readex Pro and body copy in Inclusive Sans
- expose new `font-heading` and `font-body` families in Tailwind config

## Testing
- `npm test` *(fails: Could not resolve "classnames" and "framer-motion")*

------
https://chatgpt.com/codex/tasks/task_e_68b35037805083328f10a3d95344b6ce