### PR TITLE
refactor: improve generate word list route

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,26 @@ const port = process.env.PORT || 3001;
 app.use(cors());
 app.use(express.json());
 
+const requestCounts = new Map();
+const WINDOW_MS = 60 * 1000;
+const MAX_REQUESTS = 5;
+
+const rateLimiter = (req, res, next) => {
+  const now = Date.now();
+  const ip = req.ip;
+  const entry = requestCounts.get(ip) || { count: 0, start: now };
+  if (now - entry.start > WINDOW_MS) {
+    entry.count = 0;
+    entry.start = now;
+  }
+  entry.count += 1;
+  requestCounts.set(ip, entry);
+  if (entry.count > MAX_REQUESTS) {
+    return res.status(429).json({ error: 'Too many requests, please try again later.' });
+  }
+  next();
+};
+
 const openai = new OpenAI({
   apiKey: process.env.GITHUB_TOKEN,
   baseURL: 'https://api.githubcopilot.com/v1'
@@ -28,21 +48,24 @@ const generateWordList = async (prompt) => {
   return response.choices[0].message.content;
 };
 
-app.post('/generate-word-list', async (req, res) => {
+app.post('/generate-word-list', rateLimiter, async (req, res) => {
   try {
+    if (!process.env.GITHUB_TOKEN) {
+      return res.status(500).json({ error: 'GITHUB_TOKEN not configured' });
+    }
+
     const { prompt } = req.body;
+    if (typeof prompt !== 'string' || !prompt.trim()) {
+      return res.status(400).json({ error: 'Prompt is required' });
+    }
 
-    const response = await openai.chat.completions.create({
-      model: 'gpt-4.1',
-      messages: [
-        { role: 'system', content: 'You are a helpful assistant that generates spelling bee word lists.' },
-        { role: 'user', content: prompt }
-      ],
-      temperature: 1.0,
-      top_p: 1.0
-    });
+    if (prompt.length > 200) {
+      return res.status(400).json({ error: 'Prompt too long' });
+    }
 
-    res.json({ wordList: response.choices[0].message.content });
+    const wordList = await generateWordList(prompt);
+
+    res.json({ wordList });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Internal Server Error' });


### PR DESCRIPTION
## Summary
- add simple in-memory rate limiter
- validate prompt and check for missing GITHUB_TOKEN
- reuse generateWordList function in /generate-word-list route and enforce input length

## Testing
- `npm test` *(fails: browserType.launch executable doesn't exist; Playwright browsers not installed)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_68c6be8c49a883329949e5a465effb42