### PR TITLE
refactor: use ReturnType for timer handle

### DIFF
--- a/src/utils/useTimer.ts
+++ b/src/utils/useTimer.ts
@@ -8,9 +8,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 const useTimer = (duration: number, onExpire: () => void) => {
   const [timeLeft, setTimeLeft] = useState(duration);
   const [isPaused, setIsPaused] = useState(false);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const clear = () => clearInterval(intervalRef.current as NodeJS.Timeout);
+  const clear = () =>
+    clearInterval(intervalRef.current as ReturnType<typeof setInterval>);
 
   const tick = useCallback(() => {
     setTimeLeft(prev => {


### PR DESCRIPTION
## Summary
- use `ReturnType<typeof setInterval>` for timer reference to support browser and Node environments

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous TS errors across project)*
- `npm run test:unit`
- `npm run test:e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be8f658083329c11e007eaec19ca