### PR TITLE
Fix custom word lists not loading when starting a new game

### DIFF
--- a/src/services/wordlistService.ts
+++ b/src/services/wordlistService.ts
@@ -63,6 +63,15 @@ export function setActiveListId(listId: string | null): void {
     activeListId = null;
     localStorage.removeItem('activeWordListId');
   }
+  // Clear cache to force reload on next getWordList() call
+  cachedWordList = null;
+}
+
+/**
+ * Clears the cached word list
+ */
+export function clearWordListCache(): void {
+  cachedWordList = null;
 }
 
 /**

--- a/src/spelling-bee-game.tsx
+++ b/src/spelling-bee-game.tsx
@@ -12,9 +12,10 @@ import { applyThemeClass } from './utils/theme';
 import { audioManager } from './utils/audio.ts';
 import { AudioProvider } from './AudioContext';
 import { HelpSystemProvider } from './contexts/HelpSystemContext';
+import { getWordList, clearWordListCache, type Word as WordListWord } from './services/wordlistService';
 
 // Import types
-import type { GameConfig } from './types';
+import type { GameConfig, Word } from './types';
 
 // --- Main App Component ---
 const SpellingBeeGame = () => {
@@ -28,12 +29,77 @@ const SpellingBeeGame = () => {
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [isMusicPlaying, setIsMusicPlaying] = useState(true);
 
+  // Helper function to convert WordListWord to Word type
+  const convertWord = (w: WordListWord): Word => ({
+    word: w.word,
+    syllables: w.syllables || null,
+    phonemes: null,
+    definition: w.definition || null,
+    origin: w.origin || null,
+    example: w.example || null,
+    prefix: w.prefix || null,
+    suffix: w.suffix || null,
+    pronunciation: w.pronunciation || undefined,
+    difficulty: w.difficulty,
+  });
+
   useEffect(() => {
-    fetch('words.json')
-      .then(res => res.json())
-      .then(data => setWordDatabase(data))
-      .catch(err => console.error('Failed to load word list', err));
+    // Load word list from wordlistService (supports custom word lists)
+    const loadWordList = () => {
+      getWordList()
+        .then(wordsFromService => {
+          // Convert words to the expected type
+          const words = wordsFromService.map(convertWord);
+
+          // Convert flat word array to WordDatabase format
+          const wordDatabase: GameConfig['wordDatabase'] = {
+            easy: words.filter(w => w.difficulty === 'easy' || !w.difficulty),
+            medium: words.filter(w => w.difficulty === 'medium'),
+            tricky: words.filter(w => w.difficulty === 'hard'),
+          };
+
+          // If no words have difficulties, distribute by word length
+          if (wordDatabase.easy.length === 0 && wordDatabase.medium.length === 0 && wordDatabase.tricky.length === 0) {
+            wordDatabase.easy = words.filter(w => w.word.length <= 5);
+            wordDatabase.medium = words.filter(w => w.word.length > 5 && w.word.length <= 8);
+            wordDatabase.tricky = words.filter(w => w.word.length > 8);
+          }
+
+          setWordDatabase(wordDatabase);
+        })
+        .catch(err => console.error('Failed to load word list', err));
+    };
+
+    loadWordList();
   }, []);
+
+  // Reload word list when returning to setup screen
+  useEffect(() => {
+    if (gameState === 'setup') {
+      getWordList()
+        .then(wordsFromService => {
+          // Convert words to the expected type
+          const words = wordsFromService.map(convertWord);
+
+          // Convert flat word array to WordDatabase format
+          const wordDatabase: GameConfig['wordDatabase'] = {
+            easy: words.filter(w => w.difficulty === 'easy' || !w.difficulty),
+            medium: words.filter(w => w.difficulty === 'medium'),
+            tricky: words.filter(w => w.difficulty === 'hard'),
+          };
+
+          // If no words have difficulties, distribute by word length
+          if (wordDatabase.easy.length === 0 && wordDatabase.medium.length === 0 && wordDatabase.tricky.length === 0) {
+            wordDatabase.easy = words.filter(w => w.word.length <= 5);
+            wordDatabase.medium = words.filter(w => w.word.length > 5 && w.word.length <= 8);
+            wordDatabase.tricky = words.filter(w => w.word.length > 8);
+          }
+
+          setWordDatabase(wordDatabase);
+        })
+        .catch(err => console.error('Failed to load word list', err));
+    }
+  }, [gameState]);
 
   const handleAddCustomWords = (newWords: any[]) => {
     const easy = newWords.filter(w => w.word.length <= 5);
@@ -70,6 +136,8 @@ const SpellingBeeGame = () => {
     setGameState('setup');
     setGameConfig(null);
     setGameResults(null);
+    // Clear word list cache to reload the latest selected word list
+    clearWordListCache();
   };
 
   const handleViewLeaderboard = () => {
@@ -90,15 +158,21 @@ const SpellingBeeGame = () => {
 
   const handleBackToSetup = () => {
     setGameState('setup');
+    // Clear word list cache to reload the latest selected word list
+    clearWordListCache();
   };
 
   const handleQuitToSetup = () => {
     setGameState('setup');
+    // Clear word list cache to reload the latest selected word list
+    clearWordListCache();
   };
 
   const handleExitGame = () => {
     // Return to setup when exiting game
     setGameState('setup');
+    // Clear word list cache to reload the latest selected word list
+    clearWordListCache();
   };
 
   const handleResumeGame = (savedState: any) => {


### PR DESCRIPTION
This fix addresses the issue where custom word lists weren't being loaded when starting a new game. The game was always loading words from the default 'words.json' file instead of checking for an active custom word list.

Changes:
- Modified spelling-bee-game.tsx to use getWordList() from wordlistService instead of directly fetching words.json
- Added proper type conversion from WordListWord to Word type to handle nullable field differences
- Added cache clearing mechanism to ensure word list refreshes when returning to setup
- Modified setActiveListId() in wordlistService to clear cache when word list selection changes
- Added clearWordListCache() function for manual cache clearing
- Words are now properly categorized by difficulty level or word length
- Word list reloads automatically when returning to setup screen

The wordlistService.getWordList() function properly checks for:
1. Active custom word list from localStorage
2. Falls back to default word list if no custom list is selected
3. Returns fallback words if all else fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)